### PR TITLE
update a couple problematic GitHub Wiki urls

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -59,8 +59,8 @@
         %div#logo 
           = link_to 'Freehub', root_path
         %ul
-          %li Get #{link_to "help or send feedback", "http://wiki.github.com/asalant/freehub/freehub-support"}
-          %li Check the #{link_to 'project documentation', 'http://wiki.github.com/asalant/freehub/'}
+          %li Get #{link_to "help or send feedback", "https://github.com/asalant/freehub/wiki/Freehub-Support"}
+          %li Check the #{link_to 'project documentation', 'https://github.com/asalant/freehub/wiki'}
         %ul
           %li Thanks to #{link_to 'EngineYard', 'http://www.engineyard.com'} for hosting
         %div.credit 


### PR DESCRIPTION
found these while I was snooping around.

---

http://wiki.github.com/asalant/freehub/freehub-support 
> We didn't receive a proper request from your browser. Please contact us if the problem persists.