### PR TITLE
Timezone cleanup

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -65,11 +65,12 @@ class Person < ActiveRecord::Base
   } }
 
   named_scope :after, lambda { |date| {
-      :conditions => [ "people.created_at >= ?", date.to_date.to_time.utc ]
+      :conditions => [ "convert_tz(people.created_at,'+00:00','#{Time.zone.formatted_offset}') >= ?", date.to_date.to_time.utc ]
+
   } }
 
   named_scope :before, lambda { |date| {
-      :conditions => [ "people.created_at < ?", date.to_date.to_time.utc ]
+      :conditions => [ "convert_tz(people.created_at,'+00:00','#{Time.zone.formatted_offset}') < ?", date.to_date.to_time.utc ]
   } }
 
   named_scope :matching_name, lambda { |name| {
@@ -125,7 +126,7 @@ class Person < ActiveRecord::Base
   def to_csv
     values = self.attributes.values_at(*CSV_FIELDS[:self])
     values[values.size - 3] = tag_list_with_sorting.to_s
-    values[values.size - 2] = created_at.nil? ? nil : created_at.to_s(:db)
+    values[values.size - 2] = created_at.nil? ? nil : created_at.strftime("%Y-%m-%d %H:%M")
     values[values.size - 1] = self.services.last(:membership).nil? ? nil : self.services.last(:membership).end_date.to_s(:db)
     CSV.generate_line values
   end

--- a/test/fixtures/people.yml
+++ b/test/fixtures/people.yml
@@ -38,7 +38,7 @@ mary:
   phone: 415 123-1234
   staff: false
   yob: 1972
-  created_at: 2008-01-02
+  created_at: <%= DateTime.parse('2008-01-02 07:00 PST') %>
   organization: sfbk
 
 marty:
@@ -54,7 +54,7 @@ marty:
   email: marty@example.com
   phone:
   staff: true
-  created_at: 2008-01-03
+  created_at: <%= DateTime.parse('2008-01-02 18:00 PST') %>
   organization: sfbk
 
 erik:
@@ -70,7 +70,7 @@ erik:
   email: erik@example.com
   phone:
   staff: true
-  created_at: 2008-01-04
+  created_at: <%= DateTime.parse('2008-01-03 18:00 PST') %>
   organization: sfbk
 
 
@@ -87,7 +87,7 @@ daryl:
   email:
   phone:
   staff: false
-  created_at: 2008-01-04
+  created_at: <%= DateTime.parse('2008-01-03 18:00 PST') %>
   organization: sfbk
 
 victor:
@@ -103,7 +103,7 @@ victor:
   email:
   phone:
   staff: false
-  created_at: 2008-01-05
+  created_at: <%= DateTime.parse('2008-01-04 18:00 PST') %>
   organization: sfbk
 
 carrie:
@@ -119,7 +119,7 @@ carrie:
   email:
   phone:
   staff: false
-  created_at: 2008-01-06
+  created_at: <%= DateTime.parse('2008-01-05 18:00 PST') %>
   organization: sfbk
 
 mary_scbc:
@@ -135,7 +135,7 @@ mary_scbc:
   email:
   phone:
   staff: false
-  created_at: 2008-01-07
+  created_at: <%= DateTime.parse('2008-01-06 18:00 PST') %>
   organization: scbc
 
 penny:
@@ -151,6 +151,6 @@ penny:
   email:
   phone:
   staff: false
-  created_at: 2008-03-07
+  created_at: <%= DateTime.parse('2008-01-06 18:00 EST') %>
   organization: cbi
 

--- a/test/unit/organization_test.rb
+++ b/test/unit/organization_test.rb
@@ -25,7 +25,7 @@ class OrganizationTest < ActiveSupport::TestCase
   end
 
   def test_last_visit
-    assert_equal organizations(:sfbk).last_visit.arrived_at.to_s(:db), '2007-02-02 18:02:00'
+    assert_equal organizations(:sfbk).last_visit.arrived_at, Time.zone.parse('2007-02-02 18:02')
     assert_nil organizations(:cbi).last_visit
   end
 

--- a/test/unit/person_test.rb
+++ b/test/unit/person_test.rb
@@ -113,7 +113,7 @@ class PersonTest < ActiveSupport::TestCase
   end
 
   def test_to_csv
-    assert_match /^\d+,Mary,Member,false,mary@example.com,false,415 123-1234,95105,123 Street St,,San Francisco,CA,95105,USA,1972,"mechanic, mom",2008-01-02 00:00:00,\d{4}-\d{2}-\d{2}$/, people(:mary).to_csv
+    assert_match /^\d+,Mary,Member,false,mary@example.com,false,415 123-1234,95105,123 Street St,,San Francisco,CA,95105,USA,1972,"mechanic, mom",2008-01-02 07:00,\d{4}-\d{2}-\d{2}$/, people(:mary).to_csv
   end
 
   context "A person Mary with tags" do

--- a/test/unit/visit_test.rb
+++ b/test/unit/visit_test.rb
@@ -16,8 +16,8 @@ class VisitTest < ActiveSupport::TestCase
 
   def test_for_organization_in_date_range
     from, to = Date.new(2007,2,1), Date.new(2007,2,3)
-    assert_equal 99, Visit.for_organization(organizations(:sfbk)).before(from).size
-    assert_equal 3, Visit.for_organization(organizations(:sfbk)).after(from).before(to).size
+    assert_equal 98, Visit.for_organization(organizations(:sfbk)).before(from).size
+    assert_equal 4, Visit.for_organization(organizations(:sfbk)).after(from).before(to).size
   end
 
   def test_paginated_association
@@ -30,11 +30,11 @@ class VisitTest < ActiveSupport::TestCase
                      :after => Date.new(2007,2,1),
                      :before => Date.new(2007,2,3) }
 
-    assert_equal 3, Visit.chain_finders(finder_chain).paginate.size
+    assert_equal 4, Visit.chain_finders(finder_chain).paginate.size
   end
 
   def test_to_csv
-    assert_match /^365790011,Mary,Member,mary@example.com,false,415 123-1234,95105,2007-02-01 10:01,false,true,false,Mary.+/, visits(:mary_1).to_csv
+    assert_match /^365790011,Mary,Member,mary@example.com,false,415 123-1234,95105,2007-02-01 18:01,false,true,false,Mary.+/, visits(:mary_1).to_csv
   end
 
   def test_csv_header


### PR DESCRIPTION
With Freehub building in Docker, the containers run in UTC. While tests were always running with `ENV['TIMEZONE_DEFAULT'] = 'Pacific Time (US & Canada)'` it appears that switching to running tests in the docker container surfaced a couple timezone bugs. 

This PR resolves those bugs.