### PR TITLE
Responsive layout

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,4 +34,4 @@ EXPOSE 3000
 # The main command to run when the container starts. Also
 # tell the Rails dev server to bind to all interfaces by
 # default.
-CMD ["./script/server"]
+CMD ["./script/server -b 0.0.0.0"]

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -97,9 +97,10 @@ class ReportsController < ApplicationController
     criteria = params[:criteria] || {:from => Time.now.beginning_of_year.to_date}
     criteria[:organization_id] = @organization.id
     criteria.delete_if { |key, value| value.respond_to?(:empty?) && value.empty? }
+    chartWidth = params[:chartWidth].to_i > 0  && params[:chartWidth] || 840;
 
     @report= VisitsSummary.new(criteria)
-    @gchart = Gchart.line(:size => '840x120',
+    @gchart = Gchart.line(:size => "#{chartWidth}x120",
                           :data => [@report.weeks.collect { |week| week.total_day.total }, @report.weeks.collect { |week| week.total_day.staff },
                                     @report.weeks.collect { |week| week.total_day.volunteer }, @report.weeks.collect { |week| week.total_day.member },
                                     @report.weeks.collect { |week| week.total_day.patron }],

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -61,14 +61,14 @@
         = "Times shown are #{Time.zone.name} timezone."
     %div#footer
       %div.body
-        %div#logo 
-          = link_to 'Freehub', root_path
-        %ul
+        %div.footer-item
+          = link_to 'Freehub', root_path, :id => 'logo'
+        %ul.footer-item
           %li Get #{link_to "help or send feedback", "https://github.com/asalant/freehub/wiki/Freehub-Support"}
           %li Check the #{link_to 'project documentation', 'https://github.com/asalant/freehub/wiki'}
-        %ul
+        %ul.footer-item
           %li Thanks to #{link_to 'EngineYard', 'http://www.engineyard.com'} for hosting
-        %div.credit 
+        %div.footer-item
           =image_tag("ey-logo.gif")
     :javascript
       var _gaq = _gaq || [];

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -37,23 +37,24 @@
               =link_to 'Log In', new_session_path
         -if flash[:notice]
           %span#notice= flash[:notice]
-      %div#application_nav
-        %ul.tabs
+      %div#application_header_wrapper
+        %div#application_nav
+          %ul.tabs
+            -if @organization && !@organization.new_record?
+              = tab_item('Home', organization_path(@organization))
+              = tab_item('Visits', today_visits_path(:organization_key => @organization.key))
+              = tab_item('Reports', report_path(:action => 'index', :organization_key => @organization.key))
+              -if permit? "admin or (manager of :organization)"
+                =tab_item('Settings', edit_organization_path(@organization))
+            -else
+              =tab_item('Home', root_path)
+              -if logged_in? && !current_user.organization.nil?
+                = tab_item(current_user.organization.name, organization_path(current_user.organization))
+        %div#application_header
           -if @organization && !@organization.new_record?
-            = tab_item('Home', organization_path(@organization))
-            = tab_item('Visits', today_visits_path(:organization_key => @organization.key))
-            = tab_item('Reports', report_path(:action => 'index', :organization_key => @organization.key))
-            -if permit? "admin or (manager of :organization)"
-              =tab_item('Settings', edit_organization_path(@organization))
+            %h2= link_to @organization.name, @organization
           -else
-            =tab_item('Home', root_path)
-            -if logged_in? && !current_user.organization.nil?
-              = tab_item(current_user.organization.name, organization_path(current_user.organization))
-      %div#application_header
-        -if @organization && !@organization.new_record?
-          %h2= link_to @organization.name, @organization
-        -else
-          %h2 Welcome to #{link_to 'Freehub', root_path}
+            %h2 Welcome to #{link_to 'Freehub', root_path}
       %div.content#application_body
         = yield
         %div{:style => 'clear:both;'}

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -53,7 +53,7 @@
             =tab_item('Home', root_path)
             -if logged_in? && !current_user.organization.nil?
               = tab_item(current_user.organization.name, organization_path(current_user.organization))
-      %div.content#application_body
+      %div.content#application_body.flex-container
         = yield
         %div{:style => 'clear:both;'}
       %div#application_footer

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -37,22 +37,24 @@
               =link_to 'Log In', new_session_path
         -if flash[:notice]
           %span#notice= flash[:notice]
-      %div#application_nav
-        -if @organization && !@organization.new_record?
-          %h2= link_to @organization.name, @organization
-        -else
-          %h2 Welcome to #{link_to 'Freehub', root_path}
-        %ul.tabs
+      %div#application_header.flex-container
+        %div.flex-column
           -if @organization && !@organization.new_record?
-            = tab_item('Home', organization_path(@organization))
-            = tab_item('Visits', today_visits_path(:organization_key => @organization.key))
-            = tab_item('Reports', report_path(:action => 'index', :organization_key => @organization.key))
-            -if permit? "admin or (manager of :organization)"
-              =tab_item('Settings', edit_organization_path(@organization))
+            %h2= link_to @organization.name, @organization
           -else
-            =tab_item('Home', root_path)
-            -if logged_in? && !current_user.organization.nil?
-              = tab_item(current_user.organization.name, organization_path(current_user.organization))
+            %h2 Welcome to #{link_to 'Freehub', root_path}
+        %div#application_nav.flex-column
+          %ul.tabs
+            -if @organization && !@organization.new_record?
+              = tab_item('Home', organization_path(@organization))
+              = tab_item('Visits', today_visits_path(:organization_key => @organization.key))
+              = tab_item('Reports', report_path(:action => 'index', :organization_key => @organization.key))
+              -if permit? "admin or (manager of :organization)"
+                =tab_item('Settings', edit_organization_path(@organization))
+            -else
+              =tab_item('Home', root_path)
+              -if logged_in? && !current_user.organization.nil?
+                = tab_item(current_user.organization.name, organization_path(current_user.organization))
       %div.content#application_body.flex-container
         = yield
         %div{:style => 'clear:both;'}

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -37,24 +37,22 @@
               =link_to 'Log In', new_session_path
         -if flash[:notice]
           %span#notice= flash[:notice]
-      %div#application_header_wrapper
-        %div#application_nav
-          %ul.tabs
-            -if @organization && !@organization.new_record?
-              = tab_item('Home', organization_path(@organization))
-              = tab_item('Visits', today_visits_path(:organization_key => @organization.key))
-              = tab_item('Reports', report_path(:action => 'index', :organization_key => @organization.key))
-              -if permit? "admin or (manager of :organization)"
-                =tab_item('Settings', edit_organization_path(@organization))
-            -else
-              =tab_item('Home', root_path)
-              -if logged_in? && !current_user.organization.nil?
-                = tab_item(current_user.organization.name, organization_path(current_user.organization))
-        %div#application_header
+      %div#application_nav
+        -if @organization && !@organization.new_record?
+          %h2= link_to @organization.name, @organization
+        -else
+          %h2 Welcome to #{link_to 'Freehub', root_path}
+        %ul.tabs
           -if @organization && !@organization.new_record?
-            %h2= link_to @organization.name, @organization
+            = tab_item('Home', organization_path(@organization))
+            = tab_item('Visits', today_visits_path(:organization_key => @organization.key))
+            = tab_item('Reports', report_path(:action => 'index', :organization_key => @organization.key))
+            -if permit? "admin or (manager of :organization)"
+              =tab_item('Settings', edit_organization_path(@organization))
           -else
-            %h2 Welcome to #{link_to 'Freehub', root_path}
+            =tab_item('Home', root_path)
+            -if logged_in? && !current_user.organization.nil?
+              = tab_item(current_user.organization.name, organization_path(current_user.organization))
       %div.content#application_body
         = yield
         %div{:style => 'clear:both;'}

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -69,7 +69,7 @@
           %li Check out the #{link_to 'project documentation', 'https://github.com/asalant/freehub/wiki'}
           %li &nbsp;
           %li Thanks to #{link_to 'EngineYard', 'http://www.engineyard.com'} for hosting
-        %div.footer-item
+        %div.footer-item.credit
           =image_tag("ey-logo.gif")
     :javascript
       var _gaq = _gaq || [];

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -1,6 +1,7 @@
 %html
   %head
     %meta{'http-equiv' => 'Content-Type', :content => 'text/html; charset=utf-8'}
+    %meta{:name => 'viewport', :content => 'initial-scale=1,maximum-scale=1,user-scalable=no'}
     -if @title #defined already
     -elsif @person && !@person.new_record?
       -@title = @person.full_name
@@ -28,7 +29,11 @@
             %span.log_out
               = link_to 'Log Out', session_path, :method => :delete
           -else
-            %span.log_in 
+            %span.sign_up
+              =link_to 'Sign Up', new_organization_path
+            %span
+              |
+            %span.log_in
               =link_to 'Log In', new_session_path
         -if flash[:notice]
           %span#notice= flash[:notice]

--- a/app/views/notes/edit.html.haml
+++ b/app/views/notes/edit.html.haml
@@ -1,13 +1,15 @@
-%h1 #{link_to @person.full_name, person_path(:id => @person)} : #{link_to 'Notes', notes_path(:person_id => @person)} : Edit
+%div.flex-column
 
-=error_messages_for :note
--form_for @note, :url => note_path do |f|
-  %ul
-    =labeled_input 'Regarding' do
-      -capture do
-        =notable_link(@note.notable)
-    =labeled_input 'Text', :for => :text do
-      -capture do
-        =f.text_area :text, :rows => 6
-    %li 
-      =f.submit "Create"
+  %h1 #{link_to @person.full_name, person_path(:id => @person)} : #{link_to 'Notes', notes_path(:person_id => @person)} : Edit
+
+  =error_messages_for :note
+  -form_for @note, :url => note_path do |f|
+    %ul
+      =labeled_input 'Regarding' do
+        -capture do
+          =notable_link(@note.notable)
+      =labeled_input 'Text', :for => :text do
+        -capture do
+          =f.text_area :text, :rows => 6
+      %li
+        =f.submit "Create"

--- a/app/views/notes/index.html.haml
+++ b/app/views/notes/index.html.haml
@@ -1,21 +1,24 @@
-%h1
-  =link_to @person.full_name, person_path(:id => @person)
-  = ": Notes"
+%div.flex-fullwidth
 
-=link_to 'New note', new_note_path
+  %h1
+    =link_to @person.full_name, person_path(:id => @person)
+    = ": Notes"
 
-%table
-  %tr
-    %th Notable
-    %th Text
-    %th Created at
-    %th Created by
-  -for note in @notes
-    %tr{:class => cycle('odd','even')}
-      %td= notable_link(note.notable)
-      %td.note= note_text(note)
-      %td= datetime_long(note.created_at)
-      %td= user_link(note.created_by)
-      %td= link_to 'Show', note_path(:id => note)
-      %td= link_to 'Edit', edit_note_path(:id => note)
-      %td= link_to 'Remove', note_path(:id => note), :confirm => 'Are you sure?', :method => :delete
+  =link_to 'New note', new_note_path
+
+  %table
+    %tr
+      %th Notable
+      %th Text
+      %th Created at
+      %th Created by
+      %th{:colspan => 3}
+    -for note in @notes
+      %tr{:class => cycle('odd','even')}
+        %td= notable_link(note.notable)
+        %td.note= note_text(note)
+        %td= datetime_long(note.created_at)
+        %td= user_link(note.created_by)
+        %td= link_to 'Show', note_path(:id => note)
+        %td= link_to 'Edit', edit_note_path(:id => note)
+        %td= link_to 'Remove', note_path(:id => note), :confirm => 'Are you sure?', :method => :delete

--- a/app/views/notes/new.html.haml
+++ b/app/views/notes/new.html.haml
@@ -1,10 +1,12 @@
-%h1 #{link_to @person.full_name, person_path(:id => @person)} : #{link_to 'Notes', notes_path(:person_id => @person)} : New
+%div.flex-column
 
-=error_messages_for :note
--form_for @note do |f|
-  %ul
-    =labeled_input 'Text', :for => :text do
-      -capture do
-        =f.text_area :text, :rows => 6
-    %li 
-      =f.submit "Create"
+  %h1 #{link_to @person.full_name, person_path(:id => @person)} : #{link_to 'Notes', notes_path(:person_id => @person)} : New
+
+  =error_messages_for :note
+  -form_for @note do |f|
+    %ul
+      =labeled_input 'Text', :for => :text do
+        -capture do
+          =f.text_area :text, :rows => 6
+      %li
+        =f.submit "Create"

--- a/app/views/notes/show.html.haml
+++ b/app/views/notes/show.html.haml
@@ -1,8 +1,10 @@
-%h1 #{link_to @person.full_name, person_path(:id => @person)} : #{link_to 'Notes', notes_path(:person_id => @person)} : Detail
+%div.flex-column
 
-%ul.note
-  =labeled_value 'Notable', "#{@note.notable_type} (#{@note.notable_id})"
-  =labeled_value 'Text', note_text(@note)
-  -userstamp_labeled_values @note
+  %h1 #{link_to @person.full_name, person_path(:id => @person)} : #{link_to 'Notes', notes_path(:person_id => @person)} : Detail
 
-=link_to 'Edit', edit_note_path(:id => @note)
+  %ul.note
+    =labeled_value 'Notable', "#{@note.notable_type} (#{@note.notable_id})"
+    =labeled_value 'Text', note_text(@note)
+    -userstamp_labeled_values @note
+
+  =link_to 'Edit', edit_note_path(:id => @note)

--- a/app/views/organizations/_form.html.haml
+++ b/app/views/organizations/_form.html.haml
@@ -4,7 +4,7 @@
     %p.instruct For example 'San Francisco Bike Kitchen'
 =labeled_input 'Key', :for => :key do
   -capture do
-    %div= form.text_field(:key)
+    %div= form.text_field(:key, :autocapitalize => 'none')
     %p.instruct For example 'sfbk', used for URL http://freehub.bikekitchen.org/sfbk
 =labeled_input 'Location', :for => :location do
   -capture do

--- a/app/views/organizations/_form.html.haml
+++ b/app/views/organizations/_form.html.haml
@@ -12,4 +12,4 @@
     %p.instruct For example 'San Francisco, CA'
 =labeled_input 'Timezone', :for => :timezone do
   -capture do
-    =form.time_zone_select :timezone, ActiveSupport::TimeZone.us_zones, {:default => "Pacific Time (US & Canada)"}, :class => 'medium'
+    =form.time_zone_select :timezone, ActiveSupport::TimeZone.us_zones, {:default => "Pacific Time (US & Canada)"}, :class => 'medium css_select'

--- a/app/views/organizations/_form.html.haml
+++ b/app/views/organizations/_form.html.haml
@@ -12,4 +12,4 @@
     %p.instruct For example 'San Francisco, CA'
 =labeled_input 'Timezone', :for => :timezone do
   -capture do
-    =form.time_zone_select :timezone, ActiveSupport::TimeZone.us_zones, :default => "Pacific Time (US & Canada)"
+    =form.time_zone_select :timezone, ActiveSupport::TimeZone.us_zones, {:default => "Pacific Time (US & Canada)"}, :class => 'medium'

--- a/app/views/organizations/edit.html.haml
+++ b/app/views/organizations/edit.html.haml
@@ -1,10 +1,9 @@
 %div.flex-column
   %h1 #{link_to @organization.name, @organization} : Edit
 
-  %div.column.left
-    =error_messages_for :organization
-    -form_for @organization do |f|
-      %ul
-        = render :partial => 'form', :object => f
-        %li
-          =f.submit 'Update'
+  =error_messages_for :organization
+  -form_for @organization do |f|
+    %ul
+      = render :partial => 'form', :object => f
+      %li
+        =f.submit 'Update'

--- a/app/views/organizations/edit.html.haml
+++ b/app/views/organizations/edit.html.haml
@@ -1,9 +1,10 @@
-%h1 #{link_to @organization.name, @organization} : Edit
+%div.flex-column
+  %h1 #{link_to @organization.name, @organization} : Edit
 
-%div.column.left
-  =error_messages_for :organization
-  -form_for @organization do |f|
-    %ul
-      = render :partial => 'form', :object => f
-      %li 
-        =f.submit 'Update'
+  %div.column.left
+    =error_messages_for :organization
+    -form_for @organization do |f|
+      %ul
+        = render :partial => 'form', :object => f
+        %li
+          =f.submit 'Update'

--- a/app/views/organizations/index.html.haml
+++ b/app/views/organizations/index.html.haml
@@ -1,4 +1,4 @@
-%div.column-left
+%div.flex-column
   %div.section
     %h2 About Freehub
     %p
@@ -28,7 +28,7 @@
     %h2 Quick Demo
     %p= "This #{link_to 'short movie', '/demo/summary.html'} demonstrates the basic features of Freehub."
     %p= link_to image_tag("/demo/demo.jpg", :style => "max-width: 100%; border: 1px solid lightgrey;"), '/demo/summary.html'
-%div.column-right
+%div.flex-column
   -if !logged_in?
     %div.section
       %h2 Log In

--- a/app/views/organizations/index.html.haml
+++ b/app/views/organizations/index.html.haml
@@ -30,7 +30,7 @@
     %p= link_to image_tag("/demo/demo.jpg", :style => "max-width: 100%; border: 1px solid lightgrey;"), '/demo/summary.html'
 %div.flex-column
   -if !logged_in?
-    %div.section
+    %div.section.log_in
       %h2 Log In
       -form_tag session_path, :id => 'home_login' do
         %ul

--- a/app/views/organizations/index.html.haml
+++ b/app/views/organizations/index.html.haml
@@ -42,7 +42,7 @@
               =password_field_tag 'password'
           %li
             =check_box_tag('remember_me')
-            %label.choice{:for => 'remember_me'} Remember me
+            %label.choice.remember_me{:for => 'remember_me'} Remember me
           %li
             =submit_tag 'Log In'
   %div.section

--- a/app/views/organizations/index.html.haml
+++ b/app/views/organizations/index.html.haml
@@ -1,4 +1,4 @@
-%div.column.left
+%div.column-left
   %div.section
     %h2 About Freehub
     %p
@@ -27,8 +27,8 @@
   %div.section
     %h2 Quick Demo
     %p= "This #{link_to 'short movie', '/demo/summary.html'} demonstrates the basic features of Freehub."
-    %p= link_to image_tag("/demo/demo.jpg", :style => "border: 1px solid lightgrey;"), '/demo/summary.html'
-%div.column
+    %p= link_to image_tag("/demo/demo.jpg", :style => "max-width: 100%; border: 1px solid lightgrey;"), '/demo/summary.html'
+%div.column-right
   -if !logged_in?
     %div.section
       %h2 Log In
@@ -50,7 +50,7 @@
     %p These organizations have signed up for Freehub and are actively using it.
     %table{:width => "100%"}
       %tr
-        %th
+        %th{:colspan => 2}
       -for organization in @organizations
         -if @organizations.length > 4 && (!organization.active? || organization.visits_count < 10)
           -next
@@ -59,7 +59,7 @@
             %b= organization.name
             %br
             = organization.location
-          %td{:style => 'width: 200px'}
+          %td
             -if !organization.last_visit.nil?
               = "last visit #{datetime_long(organization.last_visit.arrived_at)}"
             %br

--- a/app/views/organizations/index.html.haml
+++ b/app/views/organizations/index.html.haml
@@ -36,7 +36,7 @@
         %ul
           =labeled_input 'Login', :for => :login do
             -capture do
-              =text_field_tag 'login'
+              =text_field_tag 'login', '', :autocapitalize => 'none'
           =labeled_input 'Password', :for => :password do
             -capture do
               =password_field_tag 'password'

--- a/app/views/organizations/new.html.haml
+++ b/app/views/organizations/new.html.haml
@@ -1,20 +1,21 @@
-%h1 Register
-%div.column.left
-  %p Sign up for a new Freehub account.
-  %p
-    After you submit this form you will be able to start using Freehub while your account is pending activation.
-    You will receive an email shortly with a link to permanently activate your account.
-  -form_for @organization do |f|
-    %div.section.organization
-      %h2 Organization settings
-      =error_messages_for :organization
-      %ul 
-        = render :partial => 'organizations/form', :object => f
-    %div.section.user
-      %h2 Manager account settings
-      =error_messages_for :user
-      %ul
-        -fields_for :user do |user|
-          = render :partial => 'users/form', :object => user
-          %li
-            = f.submit 'Sign Up'
+%div.flex-column
+  %h1 Register
+  %div.column.left
+    %p Sign up for a new Freehub account.
+    %p
+      After you submit this form you will be able to start using Freehub while your account is pending activation.
+      You will receive an email shortly with a link to permanently activate your account.
+    -form_for @organization do |f|
+      %div.section.organization
+        %h2 Organization settings
+        =error_messages_for :organization
+        %ul
+          = render :partial => 'organizations/form', :object => f
+      %div.section.user
+        %h2 Manager account settings
+        =error_messages_for :user
+        %ul
+          -fields_for :user do |user|
+            = render :partial => 'users/form', :object => user
+            %li
+              = f.submit 'Sign Up'

--- a/app/views/organizations/new.html.haml
+++ b/app/views/organizations/new.html.haml
@@ -1,21 +1,20 @@
 %div.flex-column
   %h1 Register
-  %div.column.left
-    %p Sign up for a new Freehub account.
-    %p
-      After you submit this form you will be able to start using Freehub while your account is pending activation.
-      You will receive an email shortly with a link to permanently activate your account.
-    -form_for @organization do |f|
-      %div.section.organization
-        %h2 Organization settings
-        =error_messages_for :organization
-        %ul
-          = render :partial => 'organizations/form', :object => f
-      %div.section.user
-        %h2 Manager account settings
-        =error_messages_for :user
-        %ul
-          -fields_for :user do |user|
-            = render :partial => 'users/form', :object => user
-            %li
-              = f.submit 'Sign Up'
+  %p Sign up for a new Freehub account.
+  %p
+    After you submit this form you will be able to start using Freehub while your account is pending activation.
+    You will receive an email shortly with a link to permanently activate your account.
+  -form_for @organization do |f|
+    %div.section.organization
+      %h2 Organization settings
+      =error_messages_for :organization
+      %ul
+        = render :partial => 'organizations/form', :object => f
+    %div.section.user
+      %h2 Manager account settings
+      =error_messages_for :user
+      %ul
+        -fields_for :user do |user|
+          = render :partial => 'users/form', :object => user
+          %li
+            = f.submit 'Sign Up'

--- a/app/views/organizations/show.html.haml
+++ b/app/views/organizations/show.html.haml
@@ -1,7 +1,8 @@
--if current_user.activated_at.nil?
-  %div.section
-    %p.warn
-      Your account is pending activation. We've sent an activation email to #{current_user.email}.
-      Check that email account and your spam filter for the activation email.
+%div.flex-column
+  -if current_user.activated_at.nil?
+    %div.section
+      %p.warn
+        Your account is pending activation. We've sent an activation email to #{current_user.email}.
+        Check that email account and your spam filter for the activation email.
 
-= render :partial => 'visits/person_search'
+  = render :partial => 'visits/person_search'

--- a/app/views/people/_form.html.haml
+++ b/app/views/people/_form.html.haml
@@ -11,7 +11,7 @@
   =labeled_input 'Email', :for => :person_email do
     -capture do
       %span
-        = form.text_field(:email, :class => 'text short')
+        = form.text_field(:email, :class => 'text short', :autocapitalize => 'none')
       %span
         = form.check_box(:email_opt_out, :class => 'checkbox')
         %label.choice{:for => 'person_email_opt_out'} Don't send emails

--- a/app/views/people/_form.html.haml
+++ b/app/views/people/_form.html.haml
@@ -35,7 +35,7 @@
       %span
         = form.text_field(:country, :class => 'text short')
         %label{:for => 'person_country'} Country
-%div.column
+
 %ul
   =labeled_input 'Phone Number', :for => :person_phone do
     -capture do

--- a/app/views/people/_form.html.haml
+++ b/app/views/people/_form.html.haml
@@ -1,69 +1,68 @@
-%div.section
-  %div.column.left
-    %ul
-      =labeled_input 'Name', :required => true, :for => 'person_first_name' do
-        -capture do
-          %span
-            = form.text_field(:first_name, :class => 'text short')
-            %label{:for => 'person_first_name'} First
-          %span
-            = form.text_field(:last_name, :class => 'text short')
-            %label{:for => 'person_last_name'} Last
-      =labeled_input 'Email', :for => :person_email do
-        -capture do
-          %span
-            = form.text_field(:email, :class => 'text short')
-          %span
-            = form.check_box(:email_opt_out, :class => 'checkbox')
-            %label.choice{:for => 'person_email_opt_out'} Don't send emails
-      =labeled_input 'Address' do
-        -capture do
-          %div
-            = form.text_field(:street1, :class => 'text medium')
-            %label Street Address
-          %div
-            = form.text_field(:street2, :class => 'text medium')
-            %label Address Line 2
-          %span
-            = form.text_field(:city, :class => 'text short')
-            %label{:for => 'person_city'} City
-          %span
-            = form.text_field(:state, :class => 'text short')
-            %label{:for => 'person_state'} State / Province / Region
-          %span
-            = form.text_field(:postal_code, :class => 'text short')
-            %label{:for => 'person_postal_code'} Postal / Zip Code
-          %span
-            = form.text_field(:country, :class => 'text short')
-            %label{:for => 'person_country'} Country
-  %div.column
-    %ul
-      =labeled_input 'Phone Number', :for => :person_phone do
-        -capture do
-          =form.text_field(:phone, :class => 'text short')
-      =labeled_input 'Year of Birth', :for => :yob do
-        -capture do
-          =form.text_field(:yob, :class => 'text short')
-      =labeled_input 'Role' do
-        -capture do
-          = form.radio_button(:staff, false, :class => 'radio')
-          %label.choice{:for => 'person_staff_false'} Patron
-          = form.radio_button(:staff, true, :class => 'radio')
-          %label.choice{:for => 'person_staff_true'} Staff
-      -if person.new_record?
-        =labeled_input 'Services' do
-          -capture do
-            = check_box_tag(:membership, true, params[:membership], :class => 'checkbox')
-            %label.choice{:for => 'membership'} Paid Membership starting today
-            = check_box_tag(:eab, true, params[:eab], :class => 'checkbox')
-            %label.choice{:for => 'eab'} Paid Digging Rights/EAB starting today
-            = check_box_tag(:visiting, true, params[:visiting], :class => 'checkbox')
-            %label.choice{:for => 'visiting'} Visiting the shop today
-      -else
-        %li= userstamp_labeled_values(person)
-      =labeled_input 'Tags', :for => :tag_list do
-        -capture do
-          %div
-            =form.text_field(:tag_list, :class => 'text medium')
-            %label Separated by commas
-      %li= form.submit person.new_record? ? "Create" : "Update"
+
+%ul
+  =labeled_input 'Name', :required => true, :for => 'person_first_name' do
+    -capture do
+      %span
+        = form.text_field(:first_name, :class => 'text short')
+        %label{:for => 'person_first_name'} First
+      %span
+        = form.text_field(:last_name, :class => 'text short')
+        %label{:for => 'person_last_name'} Last
+  =labeled_input 'Email', :for => :person_email do
+    -capture do
+      %span
+        = form.text_field(:email, :class => 'text short')
+      %span
+        = form.check_box(:email_opt_out, :class => 'checkbox')
+        %label.choice{:for => 'person_email_opt_out'} Don't send emails
+  =labeled_input 'Address' do
+    -capture do
+      %div
+        = form.text_field(:street1, :class => 'text medium')
+        %label Street Address
+      %div
+        = form.text_field(:street2, :class => 'text medium')
+        %label Address Line 2
+      %span
+        = form.text_field(:city, :class => 'text short')
+        %label{:for => 'person_city'} City
+      %span
+        = form.text_field(:state, :class => 'text short')
+        %label{:for => 'person_state'} State / Province / Region
+      %span
+        = form.text_field(:postal_code, :class => 'text short')
+        %label{:for => 'person_postal_code'} Postal / Zip Code
+      %span
+        = form.text_field(:country, :class => 'text short')
+        %label{:for => 'person_country'} Country
+%div.column
+%ul
+  =labeled_input 'Phone Number', :for => :person_phone do
+    -capture do
+      =form.text_field(:phone, :class => 'text short')
+  =labeled_input 'Year of Birth', :for => :yob do
+    -capture do
+      =form.text_field(:yob, :class => 'text short')
+  =labeled_input 'Role' do
+    -capture do
+      = form.radio_button(:staff, false, :class => 'radio')
+      %label.choice{:for => 'person_staff_false'} Patron
+      = form.radio_button(:staff, true, :class => 'radio')
+      %label.choice{:for => 'person_staff_true'} Staff
+  -if person.new_record?
+    =labeled_input 'Services' do
+      -capture do
+        = check_box_tag(:membership, true, params[:membership], :class => 'checkbox')
+        %label.choice{:for => 'membership'} Paid Membership starting today
+        = check_box_tag(:eab, true, params[:eab], :class => 'checkbox')
+        %label.choice{:for => 'eab'} Paid Digging Rights/EAB starting today
+        = check_box_tag(:visiting, true, params[:visiting], :class => 'checkbox')
+        %label.choice{:for => 'visiting'} Visiting the shop today
+  -else
+    %li= userstamp_labeled_values(person)
+  =labeled_input 'Tags', :for => :tag_list do
+    -capture do
+      %div
+        =form.text_field(:tag_list, :class => 'text medium')
+        %label Separated by commas
+  %li= form.submit person.new_record? ? "Create" : "Update"

--- a/app/views/people/edit.html.haml
+++ b/app/views/people/edit.html.haml
@@ -1,10 +1,10 @@
-%h1= "#{link_to @person.full_name, person_path(:id => @person)} : Detail"
-%p
-  If this record is a mistake you can
-  = link_to "remove #{@person.first_name}", person_path(:id => @person), :confirm => 'Are you sure?', :method => :delete
-  from the system.
-  
-=error_messages_for :person
--form_for @person, :url => person_path(:id => @person) do |f|
-  = render :partial => 'people/form', :object => f, :locals => { :person => @person }
+%div.flex-column
+  %h1= "#{link_to @person.full_name, person_path(:id => @person)} : Detail"
+  %p
+    If this record is a mistake you can
+    = link_to "remove #{@person.first_name}", person_path(:id => @person), :confirm => 'Are you sure?', :method => :delete
+    from the system.
 
+  =error_messages_for :person
+  -form_for @person, :url => person_path(:id => @person) do |f|
+    = render :partial => 'people/form', :object => f, :locals => { :person => @person }

--- a/app/views/people/new.html.haml
+++ b/app/views/people/new.html.haml
@@ -1,10 +1,11 @@
-%h1 People : New
-%p
-  Only First Name is required. For those who wish not to be identified, please sign in as
-  = "#{ link_to 'Anonymous', report_path(:action => :people, :report => { :matching_name => 'Anonymous' }) }."
+%div.flex-column
+  %h1 People : New
+  %p
+    Only First Name is required. For those who wish not to be identified, please sign in as
+    = "#{ link_to 'Anonymous', report_path(:action => :people, :report => { :matching_name => 'Anonymous' }) }."
 
-=error_messages_for :person
--form_for @person do |f|
-  = render :partial => 'people/form', :object => f, :locals => { :person => @person }
-:javascript
-  $('person_first_name').focus();
+  =error_messages_for :person
+  -form_for @person do |f|
+    = render :partial => 'people/form', :object => f, :locals => { :person => @person }
+  :javascript
+    $('person_first_name').focus();

--- a/app/views/people/show.html.haml
+++ b/app/views/people/show.html.haml
@@ -13,27 +13,10 @@
     })(jQuery);
 
 
-%h1= @person.full_name
+%div.flex-fullwidth
+  %h1= @person.full_name
 
-%ul#summary
-  %li.person_type
-    =@person.person_type
-  -if !@person.membership
-    %li Not a member
-    %li= link_to 'Create Membership', new_service_path(:person_id => @person)
-  -elsif @person.membership.current?
-    %li.current Membership expires #{date_short @person.membership.end_date}
-    %li= link_to 'Renew', new_service_path(:person_id => @person)
-  -else
-    %li.expired Membership expired #{date_short @person.membership.end_date}
-    %li= link_to 'Renew', new_service_path(:person_id => @person)
-  %li= @person.email
-  %li= @person.postal_code
-  %li= link_to "Edit #{@person.first_name}", edit_person_path(:id => @person)
-  %li &nbsp;
-  %li= render :partial => '/taggings/index', :locals => { :person => @person }
-
-%div#sign_in
+%div#sign_in.flex-column
   %h2 Sign #{@person.first_name} In
   -form_for Visit.new(:volunteer => @person.staff?), :url => visits_path(:person_id => @person.id) do |f|
     =hidden_field_tag :destination, today_visits_path
@@ -50,8 +33,27 @@
       %li
         =f.submit "Sign In"
 
-%div.section
-  %div.column.left#visits
+%div.flex-column
+  %ul#summary
+    %li.person_type
+      =@person.person_type
+    -if !@person.membership
+      %li Not a member
+      %li= link_to 'Create Membership', new_service_path(:person_id => @person)
+    -elsif @person.membership.current?
+      %li.current Membership expires #{date_short @person.membership.end_date}
+      %li= link_to 'Renew', new_service_path(:person_id => @person)
+    -else
+      %li.expired Membership expired #{date_short @person.membership.end_date}
+      %li= link_to 'Renew', new_service_path(:person_id => @person)
+    %li= @person.email
+    %li= @person.postal_code
+    %li= link_to "Edit #{@person.first_name}", edit_person_path(:id => @person)
+    %li &nbsp;
+    %li= render :partial => '/taggings/index', :locals => { :person => @person }
+
+%div#visits.flex-column
+  %div.section
     %h2 Recent Visits
     =link_to 'Add a Visit', new_visit_path(:person_id => @person), :class => 'add_link'
     -visits = @person.visits.paginate(:size => 5)
@@ -67,7 +69,9 @@
               %span.note= note_text(visit.note)
       %p
         =link_to "See All #{visits.size} Visits with Details", visits_path(:organization_key => @organization.key, :person_id => @person)
-  %div.column#services
+
+%div#services.flex-column
+  %div.section
     %h2 Current Services
     =link_to 'Add A Service', new_service_path(:person_id => @person), :class => 'add_link'
     -services = @person.services.paginate(:size => 5)
@@ -84,17 +88,18 @@
       %p
         =link_to "See All #{services.size} Services with Details", services_path(:organization_key => @organization.key, :person_id => @person)
 
-%div.section#notes
-  %h2 Recent Notes
-  =link_to 'Add A Note', new_note_path(:person_id => @person), :class => 'add_link'
-  -notes, notes_count = Note.for_person(@person, :limit => 3), Note.count_for_person(@person)
-  -if notes.empty?
-    %p.list_status No past notes.
-  -else
-    %ul
-      -for note in notes
-        %li{:class => cycle('odd','even', :name => notes)}
-          %span.what= "#{user_link(note.created_by)} #{time_ago_in_words(note.created_at)} ago said:"
-          %span.note= note_text(note)
-    %p
-      =link_to "See All #{notes_count} Notes.", notes_path(:organization_key => @organization.key, :person_id => @person)
+%div#notes.flex-fullwidth
+  %div.section
+    %h2 Recent Notes
+    =link_to 'Add A Note', new_note_path(:person_id => @person), :class => 'add_link'
+    -notes, notes_count = Note.for_person(@person, :limit => 3), Note.count_for_person(@person)
+    -if notes.empty?
+      %p.list_status No past notes.
+    -else
+      %ul
+        -for note in notes
+          %li{:class => cycle('odd','even', :name => notes)}
+            %span.what= "#{user_link(note.created_by)} #{time_ago_in_words(note.created_at)} ago said:"
+            %span.note= note_text(note)
+      %p
+        =link_to "See All #{notes_count} Notes.", notes_path(:organization_key => @organization.key, :person_id => @person)

--- a/app/views/reports/index.html.haml
+++ b/app/views/reports/index.html.haml
@@ -1,6 +1,7 @@
-%h1 Listing reports
+%div.flex-fullwidth
+  %h1 Listing reports
 
-%div.column.left
+%div.flex-column
   %div.section
     %h2 People
     %p
@@ -12,7 +13,7 @@
       The #{link_to 'Services Report', report_path(:action => 'services', :organization_key => @organization.key)}
       lists services by type (Membership, Class, Digging Rights) in a date range and can be exported as CSV for use in a spreadsheet program.
 
-%div.column
+%div.flex-column
   %div.section
     %h2 Visits
     %p
@@ -23,4 +24,3 @@
     %p
       The #{link_to 'Summary Report', report_path(:action => 'summary', :organization_key => @organization.key)}
       provides a high level view of who is visiting the shop when.
-

--- a/app/views/reports/people.html.haml
+++ b/app/views/reports/people.html.haml
@@ -2,7 +2,7 @@
   %h1
     =link_to 'Reports', reports_path
     = ' : People'
-    
+
   -form_tag report_path(:action => 'people'), :method => :get do
     %ul
       =labeled_input 'Matching name', :for => 'report[matching_name]' do
@@ -25,10 +25,10 @@
       =labeled_input 'Date Range', :for => 'date_from' do
         -capture do
           %span
-            =calendar_date_select_tag "report[after]", @report[:after], :year_range => 3.years.ago..1.years.from_now
+            =calendar_date_select_tag "report[after]", @report[:after], :year_range => 10.years.ago..1.years.from_now
             %label{:for => 'report[after]'} Created After
           %span
-            =calendar_date_select_tag "report[before]", @report[:before], :year_range => 3.years.ago..1.years.from_now
+            =calendar_date_select_tag "report[before]", @report[:before], :year_range => 10.years.ago..1.years.from_now
             %label{:for => 'report[before]'} Created Before
           %p.instruct Leave one or both blank to search without date constraints.
       %li

--- a/app/views/reports/people.html.haml
+++ b/app/views/reports/people.html.haml
@@ -2,37 +2,37 @@
   %h1
     =link_to 'Reports', reports_path
     = ' : People'
-  %div.column
-    -form_tag report_path(:action => 'people'), :method => :get do
-      %ul
-        =labeled_input 'Matching name', :for => 'report[matching_name]' do
-          -capture do
-            %div= text_field_tag 'report[matching_name]', @report[:matching_name]
-            %p.instruct Match 3 or more letters in a person's first and last name.
-        =labeled_input 'Type', :for => 'report[is_staff]' do
-          -capture do
-            %div
-              %span.option
-                = radio_button_tag 'report[is_staff]', "all", @report[:is_staff] == nil
-                %label{:for => 'report[is_staff]'} All
-              %span.option
-                = radio_button_tag 'report[is_staff]', 1, @report[:is_staff] == "1"
-                %label{:for => 'report[is_staff]'} Staff
-              %span.option
-                = radio_button_tag 'report[is_staff]', 0, @report[:is_staff] == "0"
-                %label{:for => 'report[is_staff]'} Patrons
-            %p.instruct Select All, Staff, or Patrons
-        =labeled_input 'Date Range', :for => 'date_from' do
-          -capture do
-            %span
-              =calendar_date_select_tag "report[after]", @report[:after], :year_range => 3.years.ago..1.years.from_now
-              %label{:for => 'report[after]'} Created After
-            %span
-              =calendar_date_select_tag "report[before]", @report[:before], :year_range => 3.years.ago..1.years.from_now
-              %label{:for => 'report[before]'} Created Before
-            %p.instruct Leave one or both blank to search without date constraints.
-        %li
-          =submit_tag "Update"
+    
+  -form_tag report_path(:action => 'people'), :method => :get do
+    %ul
+      =labeled_input 'Matching name', :for => 'report[matching_name]' do
+        -capture do
+          %div= text_field_tag 'report[matching_name]', @report[:matching_name]
+          %p.instruct Match 3 or more letters in a person's first and last name.
+      =labeled_input 'Type', :for => 'report[is_staff]' do
+        -capture do
+          %div
+            %span.option
+              = radio_button_tag 'report[is_staff]', "all", @report[:is_staff] == nil
+              %label{:for => 'report[is_staff]'} All
+            %span.option
+              = radio_button_tag 'report[is_staff]', 1, @report[:is_staff] == "1"
+              %label{:for => 'report[is_staff]'} Staff
+            %span.option
+              = radio_button_tag 'report[is_staff]', 0, @report[:is_staff] == "0"
+              %label{:for => 'report[is_staff]'} Patrons
+          %p.instruct Select All, Staff, or Patrons
+      =labeled_input 'Date Range', :for => 'date_from' do
+        -capture do
+          %span
+            =calendar_date_select_tag "report[after]", @report[:after], :year_range => 3.years.ago..1.years.from_now
+            %label{:for => 'report[after]'} Created After
+          %span
+            =calendar_date_select_tag "report[before]", @report[:before], :year_range => 3.years.ago..1.years.from_now
+            %label{:for => 'report[before]'} Created Before
+          %p.instruct Leave one or both blank to search without date constraints.
+      %li
+        =submit_tag "Update"
 
 %div.flex-fullwidth
   %div.section

--- a/app/views/reports/people.html.haml
+++ b/app/views/reports/people.html.haml
@@ -1,74 +1,77 @@
-%h1
-  =link_to 'Reports', reports_path
-  = ' : People'
-%div.column
-  -form_tag report_path(:action => 'people'), :method => :get do
-    %ul
-      =labeled_input 'Matching name', :for => 'report[matching_name]' do
-        -capture do
-          %div= text_field_tag 'report[matching_name]', @report[:matching_name]
-          %p.instruct Match 3 or more letters in a person's first and last name.
-      =labeled_input 'Type', :for => 'report[is_staff]' do
-        -capture do
-          %span.option
-            = radio_button_tag 'report[is_staff]', "all", @report[:is_staff] == nil
-            %label{:for => 'report[is_staff]'} All
-          %span.option
-            = radio_button_tag 'report[is_staff]', 1, @report[:is_staff] == "1"
-            %label{:for => 'report[is_staff]'} Staff
-          %span.option
-            = radio_button_tag 'report[is_staff]', 0, @report[:is_staff] == "0"
-            %label{:for => 'report[is_staff]'} Patrons
-          %p.instruct Select All, Staff, or Patrons
-      =labeled_input 'Date Range', :for => 'date_from' do
-        -capture do
-          %span
-            =calendar_date_select_tag "report[after]", @report[:after], :year_range => 3.years.ago..1.years.from_now
-            %label{:for => 'report[after]'} Created After
-          %span
-            =calendar_date_select_tag "report[before]", @report[:before], :year_range => 3.years.ago..1.years.from_now
-            %label{:for => 'report[before]'} Created Before
-          %p.instruct Leave one or both blank to search without date constraints.
-      %li 
-        =submit_tag "Update"
+%div.flex-column
+  %h1
+    =link_to 'Reports', reports_path
+    = ' : People'
+  %div.column
+    -form_tag report_path(:action => 'people'), :method => :get do
+      %ul
+        =labeled_input 'Matching name', :for => 'report[matching_name]' do
+          -capture do
+            %div= text_field_tag 'report[matching_name]', @report[:matching_name]
+            %p.instruct Match 3 or more letters in a person's first and last name.
+        =labeled_input 'Type', :for => 'report[is_staff]' do
+          -capture do
+            %div
+              %span.option
+                = radio_button_tag 'report[is_staff]', "all", @report[:is_staff] == nil
+                %label{:for => 'report[is_staff]'} All
+              %span.option
+                = radio_button_tag 'report[is_staff]', 1, @report[:is_staff] == "1"
+                %label{:for => 'report[is_staff]'} Staff
+              %span.option
+                = radio_button_tag 'report[is_staff]', 0, @report[:is_staff] == "0"
+                %label{:for => 'report[is_staff]'} Patrons
+            %p.instruct Select All, Staff, or Patrons
+        =labeled_input 'Date Range', :for => 'date_from' do
+          -capture do
+            %span
+              =calendar_date_select_tag "report[after]", @report[:after], :year_range => 3.years.ago..1.years.from_now
+              %label{:for => 'report[after]'} Created After
+            %span
+              =calendar_date_select_tag "report[before]", @report[:before], :year_range => 3.years.ago..1.years.from_now
+              %label{:for => 'report[before]'} Created Before
+            %p.instruct Leave one or both blank to search without date constraints.
+        %li
+          =submit_tag "Update"
 
-%div.section
-  -if @people.empty?
-    %div.list_status No people for date range.
-  -else
-    %div.list_status #{@people.to_a.size} of #{@people.size} people shown.
-    %table
-      %tr
-      %th Name
-      %th Staff
-      %th Email
-      %th Phone
-      %th City
-      %th State
-      %th Postal code
-      %th Created
-      -for person in @people
-        %tr{:class => cycle('odd','even')}
-          %td{:style => 'width:200px;'}
-            =link_to(person.full_name, person_path(:id => person))
-          %td
-            = person.staff
-          %td{:style => 'width:200px;'}
-            = person.email
-          %td 
-            = person.phone
-          %td 
-            = person.city
-          %td 
-            = person.state
-          %td 
-            = person.postal_code
-          %td 
-            = datetime_short(person.created_at)
-      %tr.list_controls
-        %td{:colspan => 8}
-          -if @people.next_page? || @people.previous_page?
-            %div.paginating_links
-              More: #{paginating_links(@people, :params => { :report => params[:report] } )}
-          %div.export
-            =link_to 'Export all', report_path(:action => 'people', :params => { :report => params[:report], :format => 'csv' })
+%div.flex-fullwidth
+  %div.section
+    -if @people.empty?
+      %div.list_status No people for date range.
+    -else
+      %div.list_status #{@people.to_a.size} of #{@people.size} people shown.
+      %table
+        %tr
+        %th Name
+        %th Staff
+        %th Email
+        %th Phone
+        %th City
+        %th State
+        %th Postal code
+        %th Created
+        -for person in @people
+          %tr{:class => cycle('odd','even')}
+            %td{:style => 'width:200px;'}
+              =link_to(person.full_name, person_path(:id => person))
+            %td
+              = person.staff
+            %td{:style => 'width:200px;'}
+              = person.email
+            %td
+              = person.phone
+            %td
+              = person.city
+            %td
+              = person.state
+            %td
+              = person.postal_code
+            %td
+              = datetime_short(person.created_at)
+        %tr.list_controls
+          %td{:colspan => 8}
+            -if @people.next_page? || @people.previous_page?
+              %div.paginating_links
+                More: #{paginating_links(@people, :params => { :report => params[:report] } )}
+            %div.export
+              =link_to 'Export all', report_path(:action => 'people', :params => { :report => params[:report], :format => 'csv' })

--- a/app/views/reports/services.html.haml
+++ b/app/views/reports/services.html.haml
@@ -1,61 +1,63 @@
-%h1
-  =link_to 'Reports', reports_path
-  = ' : Services'
-  
-%div.column
-  -form_tag report_path(:action => 'services'), :method => :get do
-    %ul
-      =labeled_input 'Service Type', :for => :service_type do
-        -capture do
-          -@service_types.each do |service_type|
-            =check_box_tag 'report[for_service_types][]', service_type.id, @report[:for_service_types].include?(service_type.id)
-            %label.inline= service_type.name
-      =labeled_input 'Date Range', :for => 'date_from' do
-        -capture do
-          %span
-            =calendar_date_select_tag "report[end_after]", @report[:end_after], :year_range => 3.years.ago..1.years.from_now
-            %label{:for => 'report[end_after]'} Ending After
-          %span
-            =calendar_date_select_tag "report[end_before]", @report[:end_before], :year_range => 3.years.ago..1.years.from_now
-            %label{:for => 'report[end_before]'} Ending Before
-          %p.instruct Leave one or both blank to search without date constraints.
-      %li 
-        =submit_tag "Update"
+%div.flex-column
+  %h1
+    =link_to 'Reports', reports_path
+    = ' : Services'
 
-%div.section
-  -if @services.empty?
-    %div.list_status No services for date range.
-  -else
-    %div.list_status #{@services.to_a.size} of #{@services.size} services shown.
-    %table
-      %tr
-        %th Name
-        %th Service type
-        %th Start date
-        %th End date
-        %th Paid
-        %th Volunteered
-        %th Note
-      -for service in @services
-        %tr{:class => cycle('odd','even')}
-          %td{:style => 'width:200px;'}
-            =link_to(service.person.full_name, person_path(:id => service.person))
-          %td{:style => 'width:100px;'}
-            = service.service_type.name
-          %td 
-            = date_short(service.start_date)
-          %td 
-            = date_short(service.end_date)
-          %td 
-            = service.paid
-          %td 
-            = service.volunteered
-          %td.note{:style => 'width:360px;'}
-            =note_text(service.note)
-      %tr.list_controls
-        %td{:colspan => 7}
-          -if @services.next_page? || @services.previous_page?
-            %div.paginating_links
-              More: #{paginating_links(@services, :params => { :report => params[:report] } )}
-          %div.export
-            =link_to 'Export all', report_path(:action => 'services', :params => { :report => params[:report], :format => 'csv' })
+  %div.column
+    -form_tag report_path(:action => 'services'), :method => :get do
+      %ul
+        =labeled_input 'Service Type', :for => :service_type do
+          -capture do
+            -@service_types.each do |service_type|
+              =check_box_tag 'report[for_service_types][]', service_type.id, @report[:for_service_types].include?(service_type.id)
+              %label.inline= service_type.name
+        =labeled_input 'Date Range', :for => 'date_from' do
+          -capture do
+            %span
+              =calendar_date_select_tag "report[end_after]", @report[:end_after], :year_range => 3.years.ago..1.years.from_now
+              %label{:for => 'report[end_after]'} Ending After
+            %span
+              =calendar_date_select_tag "report[end_before]", @report[:end_before], :year_range => 3.years.ago..1.years.from_now
+              %label{:for => 'report[end_before]'} Ending Before
+            %p.instruct Leave one or both blank to search without date constraints.
+        %li
+          =submit_tag "Update"
+
+%div.flex-fullwidth
+  %div.section
+    -if @services.empty?
+      %div.list_status No services for date range.
+    -else
+      %div.list_status #{@services.to_a.size} of #{@services.size} services shown.
+      %table
+        %tr
+          %th Name
+          %th Service type
+          %th Start date
+          %th End date
+          %th Paid
+          %th Volunteered
+          %th Note
+        -for service in @services
+          %tr{:class => cycle('odd','even')}
+            %td{:style => 'width:200px;'}
+              =link_to(service.person.full_name, person_path(:id => service.person))
+            %td{:style => 'width:100px;'}
+              = service.service_type.name
+            %td
+              = date_short(service.start_date)
+            %td
+              = date_short(service.end_date)
+            %td
+              = service.paid
+            %td
+              = service.volunteered
+            %td.note{:style => 'width:360px;'}
+              =note_text(service.note)
+        %tr.list_controls
+          %td{:colspan => 7}
+            -if @services.next_page? || @services.previous_page?
+              %div.paginating_links
+                More: #{paginating_links(@services, :params => { :report => params[:report] } )}
+            %div.export
+              =link_to 'Export all', report_path(:action => 'services', :params => { :report => params[:report], :format => 'csv' })

--- a/app/views/reports/services.html.haml
+++ b/app/views/reports/services.html.haml
@@ -2,26 +2,25 @@
   %h1
     =link_to 'Reports', reports_path
     = ' : Services'
-
-  %div.column
-    -form_tag report_path(:action => 'services'), :method => :get do
-      %ul
-        =labeled_input 'Service Type', :for => :service_type do
-          -capture do
-            -@service_types.each do |service_type|
-              =check_box_tag 'report[for_service_types][]', service_type.id, @report[:for_service_types].include?(service_type.id)
-              %label.inline= service_type.name
-        =labeled_input 'Date Range', :for => 'date_from' do
-          -capture do
-            %span
-              =calendar_date_select_tag "report[end_after]", @report[:end_after], :year_range => 3.years.ago..1.years.from_now
-              %label{:for => 'report[end_after]'} Ending After
-            %span
-              =calendar_date_select_tag "report[end_before]", @report[:end_before], :year_range => 3.years.ago..1.years.from_now
-              %label{:for => 'report[end_before]'} Ending Before
-            %p.instruct Leave one or both blank to search without date constraints.
-        %li
-          =submit_tag "Update"
+    
+  -form_tag report_path(:action => 'services'), :method => :get do
+    %ul
+      =labeled_input 'Service Type', :for => :service_type do
+        -capture do
+          -@service_types.each do |service_type|
+            =check_box_tag 'report[for_service_types][]', service_type.id, @report[:for_service_types].include?(service_type.id)
+            %label.inline= service_type.name
+      =labeled_input 'Date Range', :for => 'date_from' do
+        -capture do
+          %span
+            =calendar_date_select_tag "report[end_after]", @report[:end_after], :year_range => 3.years.ago..1.years.from_now
+            %label{:for => 'report[end_after]'} Ending After
+          %span
+            =calendar_date_select_tag "report[end_before]", @report[:end_before], :year_range => 3.years.ago..1.years.from_now
+            %label{:for => 'report[end_before]'} Ending Before
+          %p.instruct Leave one or both blank to search without date constraints.
+      %li
+        =submit_tag "Update"
 
 %div.flex-fullwidth
   %div.section

--- a/app/views/reports/services.html.haml
+++ b/app/views/reports/services.html.haml
@@ -2,7 +2,7 @@
   %h1
     =link_to 'Reports', reports_path
     = ' : Services'
-    
+
   -form_tag report_path(:action => 'services'), :method => :get do
     %ul
       =labeled_input 'Service Type', :for => :service_type do
@@ -13,10 +13,10 @@
       =labeled_input 'Date Range', :for => 'date_from' do
         -capture do
           %span
-            =calendar_date_select_tag "report[end_after]", @report[:end_after], :year_range => 3.years.ago..1.years.from_now
+            =calendar_date_select_tag "report[end_after]", @report[:end_after], :year_range => 10.years.ago..1.years.from_now
             %label{:for => 'report[end_after]'} Ending After
           %span
-            =calendar_date_select_tag "report[end_before]", @report[:end_before], :year_range => 3.years.ago..1.years.from_now
+            =calendar_date_select_tag "report[end_before]", @report[:end_before], :year_range => 10.years.ago..1.years.from_now
             %label{:for => 'report[end_before]'} Ending Before
           %p.instruct Leave one or both blank to search without date constraints.
       %li

--- a/app/views/reports/summary.html.haml
+++ b/app/views/reports/summary.html.haml
@@ -19,10 +19,10 @@
       =labeled_input 'Date Range', :for => 'criteria[from]' do
         -capture do
           %span
-            =calendar_date_select_tag "criteria[from]", @report.criteria[:from], :year_range => 3.years.ago..1.years.from_now
+            =calendar_date_select_tag "criteria[from]", @report.criteria[:from], :year_range => 10.years.ago..1.years.from_now
             %label{:for => 'criteria[from]'} Date From
           %span
-            =calendar_date_select_tag "criteria[to]", @report.criteria[:to], :year_range => 3.years.ago..1.years.from_now
+            =calendar_date_select_tag "criteria[to]", @report.criteria[:to], :year_range => 10.years.ago..1.years.from_now
             %label{:for => 'criteria[to]'} Date To
           %p.instruct Leave one or both blank to search without date constraints.
       %li

--- a/app/views/reports/summary.html.haml
+++ b/app/views/reports/summary.html.haml
@@ -1,72 +1,86 @@
-%h1
-  =link_to 'Reports', reports_path
-  = ' : Summary'
+-content_for :head do
+  :javascript
+    (function($)
+    {
+      $(function()
+      {
+        $('form input[name=chartWidth]').val($('.flex-fullwidth').first().width());
+      });
+    })(jQuery);
 
--form_tag report_path(:action => 'summary'), :method => :get do
-  %ul
-    =labeled_input 'Date Range', :for => 'criteria[from]' do
-      -capture do
-        %span
-          =calendar_date_select_tag "criteria[from]", @report.criteria[:from], :year_range => 3.years.ago..1.years.from_now
-          %label{:for => 'criteria[from]'} Date From
-        %span
-          =calendar_date_select_tag "criteria[to]", @report.criteria[:to], :year_range => 3.years.ago..1.years.from_now
-          %label{:for => 'criteria[to]'} Date To
-        %p.instruct Leave one or both blank to search without date constraints.
-    %li
-      =submit_tag "Update"
+%div.flex-column
+  %h1
+    =link_to 'Reports', reports_path
+    = ' : Summary'
 
--if @report.days.empty?
-  %div.list_status No visits for date range.
--else
-  %div.section
-    %h2 Visits by Week
-    = @gchart
-    %table
-      %tr
-        %th Starting
-        %th Staff
-        %th Volunteers
-        %th Members
-        %th Patrons
-        %th Total
-      -for week in @report.weeks
-        %tr{:class => cycle('odd','even')}
-          %td
-            = date_short(week.start)
-          %td
-            = week.total_day.staff
-          %td
-            = week.total_day.volunteer
-          %td
-            = week.total_day.member
-          %td
-            = week.total_day.patron
-          %td
-            = week.total_day.total
-  %div.section
-    %h2 Visits by Day
-    %table
-      %tr
-        %th Day
-        %th Staff
-        %th Volunteers
-        %th Members
-        %th Patrons
-        %th Total
-      -for day in @report.days
-        -if day.total == 0
-          -next
-        %tr{:class => cycle('odd','even')}
-          %td
-            =link_to date_long(day.date), day_visits_path(day.date)
-          %td
-            = day.staff
-          %td
-            = day.volunteer
-          %td
-            = day.member
-          %td
-            = day.patron
-          %td
-            = day.total
+  -form_tag report_path(:action => 'summary'), :method => :get do
+    =hidden_field_tag 'chartWidth'
+    %ul
+      =labeled_input 'Date Range', :for => 'criteria[from]' do
+        -capture do
+          %span
+            =calendar_date_select_tag "criteria[from]", @report.criteria[:from], :year_range => 3.years.ago..1.years.from_now
+            %label{:for => 'criteria[from]'} Date From
+          %span
+            =calendar_date_select_tag "criteria[to]", @report.criteria[:to], :year_range => 3.years.ago..1.years.from_now
+            %label{:for => 'criteria[to]'} Date To
+          %p.instruct Leave one or both blank to search without date constraints.
+      %li
+        =submit_tag "Update"
+
+%div.flex-fullwidth
+  -if @report.days.empty?
+    %div.list_status No visits for date range.
+  -else
+    %div.section
+      %h2 Visits by Week
+      %div.gchart
+        = @gchart
+      %table
+        %tr
+          %th Starting
+          %th Staff
+          %th Volunteers
+          %th Members
+          %th Patrons
+          %th Total
+        -for week in @report.weeks
+          %tr{:class => cycle('odd','even')}
+            %td
+              = date_short(week.start)
+            %td
+              = week.total_day.staff
+            %td
+              = week.total_day.volunteer
+            %td
+              = week.total_day.member
+            %td
+              = week.total_day.patron
+            %td
+              = week.total_day.total
+    %div.section
+      %h2 Visits by Day
+      %table
+        %tr
+          %th Day
+          %th Staff
+          %th Volunteers
+          %th Members
+          %th Patrons
+          %th Total
+        -for day in @report.days
+          -if day.total == 0
+            -next
+          %tr{:class => cycle('odd','even')}
+            %td
+              =link_to date_long(day.date), day_visits_path(day.date)
+            %td
+              = day.staff
+            %td
+              = day.volunteer
+            %td
+              = day.member
+            %td
+              = day.patron
+            %td
+              = day.total

--- a/app/views/reports/summary.html.haml
+++ b/app/views/reports/summary.html.haml
@@ -2,20 +2,19 @@
   =link_to 'Reports', reports_path
   = ' : Summary'
 
-%div.column
-  -form_tag report_path(:action => 'summary'), :method => :get do
-    %ul
-      =labeled_input 'Date Range', :for => 'criteria[from]' do
-        -capture do
-          %span
-            =calendar_date_select_tag "criteria[from]", @report.criteria[:from], :year_range => 3.years.ago..1.years.from_now
-            %label{:for => 'criteria[from]'} Date From
-          %span
-            =calendar_date_select_tag "criteria[to]", @report.criteria[:to], :year_range => 3.years.ago..1.years.from_now
-            %label{:for => 'criteria[to]'} Date To
-          %p.instruct Leave one or both blank to search without date constraints.
-      %li 
-        =submit_tag "Update"
+-form_tag report_path(:action => 'summary'), :method => :get do
+  %ul
+    =labeled_input 'Date Range', :for => 'criteria[from]' do
+      -capture do
+        %span
+          =calendar_date_select_tag "criteria[from]", @report.criteria[:from], :year_range => 3.years.ago..1.years.from_now
+          %label{:for => 'criteria[from]'} Date From
+        %span
+          =calendar_date_select_tag "criteria[to]", @report.criteria[:to], :year_range => 3.years.ago..1.years.from_now
+          %label{:for => 'criteria[to]'} Date To
+        %p.instruct Leave one or both blank to search without date constraints.
+    %li
+      =submit_tag "Update"
 
 -if @report.days.empty?
   %div.list_status No visits for date range.
@@ -33,17 +32,17 @@
         %th Total
       -for week in @report.weeks
         %tr{:class => cycle('odd','even')}
-          %td 
+          %td
             = date_short(week.start)
-          %td 
+          %td
             = week.total_day.staff
-          %td 
+          %td
             = week.total_day.volunteer
-          %td 
+          %td
             = week.total_day.member
-          %td 
+          %td
             = week.total_day.patron
-          %td 
+          %td
             = week.total_day.total
   %div.section
     %h2 Visits by Day
@@ -59,15 +58,15 @@
         -if day.total == 0
           -next
         %tr{:class => cycle('odd','even')}
-          %td 
+          %td
             =link_to date_long(day.date), day_visits_path(day.date)
-          %td 
+          %td
             = day.staff
-          %td 
+          %td
             = day.volunteer
-          %td 
+          %td
             = day.member
-          %td 
+          %td
             = day.patron
-          %td 
+          %td
             = day.total

--- a/app/views/reports/visits.html.haml
+++ b/app/views/reports/visits.html.haml
@@ -1,49 +1,51 @@
-%h1
-  =link_to 'Reports', reports_path
-  = ' : Visits'
+%div.flex-column
+  %h1
+    =link_to 'Reports', reports_path
+    = ' : Visits'
 
--form_tag report_path(:action => 'visits'), :method => :get do
-  %ul
-    =labeled_input 'Date Range', :for => 'date_from' do
-      -capture do
-        %span
-          =calendar_date_select_tag "report[after]", @report[:after], :year_range => 3.years.ago..1.years.from_now
-          %label{:for => 'report[after]'} Date From
-        %span
-          =calendar_date_select_tag "report[before]", @report[:before], :year_range => 3.years.ago..1.years.from_now
-          %label{:for => 'report[before]'} Date To
-        %p.instruct Leave one or both blank to search without date constraints.
-    %li
-      =submit_tag "Update"
+  -form_tag report_path(:action => 'visits'), :method => :get do
+    %ul
+      =labeled_input 'Date Range', :for => 'date_from' do
+        -capture do
+          %span
+            =calendar_date_select_tag "report[after]", @report[:after], :year_range => 3.years.ago..1.years.from_now
+            %label{:for => 'report[after]'} Date From
+          %span
+            =calendar_date_select_tag "report[before]", @report[:before], :year_range => 3.years.ago..1.years.from_now
+            %label{:for => 'report[before]'} Date To
+          %p.instruct Leave one or both blank to search without date constraints.
+      %li
+        =submit_tag "Update"
 
-%div.section
-  -if @visits.empty?
-    %div.list_status No visits for date range.
-  -else
-    %div.list_status #{@visits.to_a.size} of #{@visits.size} visits shown.
-    %table
-      %tr
-        %th Name
-        %th Type
-        %th Volunteer
-        %th Datetime
-        %th Note
-      -for visit in @visits
-        %tr{:class => cycle('odd','even')}
-          %td{:style => 'width:200px;'}
-            =link_to(visit.person.full_name, person_path(:id => visit.person))
-          %td
-            = visit.person.staff? ? 'Staff' : 'Patron'
-          %td
-            = visit.volunteer?
-          %td
-            = datetime_long(visit.arrived_at)
-          %td.note{:style => 'width:360px;'}
-            = note_text(visit.note)
-      %tr.list_controls
-        %td{:colspan => 5}
-          -if @visits.next_page? || @visits.previous_page?
-            %div.paginating_links
-              More: #{paginating_links(@visits, :params => { :report => params[:report] } )}
-          %div.export
-            =link_to 'Export all', report_path(:action => 'visits', :params => { :report => params[:report], :format => 'csv' })
+%div.flex-fullwidth
+  %div.section
+    -if @visits.empty?
+      %div.list_status No visits for date range.
+    -else
+      %div.list_status #{@visits.to_a.size} of #{@visits.size} visits shown.
+      %table
+        %tr
+          %th Name
+          %th Type
+          %th Volunteer
+          %th Datetime
+          %th Note
+        -for visit in @visits
+          %tr{:class => cycle('odd','even')}
+            %td{:style => 'width:200px;'}
+              =link_to(visit.person.full_name, person_path(:id => visit.person))
+            %td
+              = visit.person.staff? ? 'Staff' : 'Patron'
+            %td
+              = visit.volunteer?
+            %td
+              = datetime_long(visit.arrived_at)
+            %td.note{:style => 'width:360px;'}
+              = note_text(visit.note)
+        %tr.list_controls
+          %td{:colspan => 5}
+            -if @visits.next_page? || @visits.previous_page?
+              %div.paginating_links
+                More: #{paginating_links(@visits, :params => { :report => params[:report] } )}
+            %div.export
+              =link_to 'Export all', report_path(:action => 'visits', :params => { :report => params[:report], :format => 'csv' })

--- a/app/views/reports/visits.html.haml
+++ b/app/views/reports/visits.html.haml
@@ -2,20 +2,20 @@
   =link_to 'Reports', reports_path
   = ' : Visits'
 
-%div.column
-  -form_tag report_path(:action => 'visits'), :method => :get do
-    %ul
-      =labeled_input 'Date Range', :for => 'date_from' do
-        -capture do
-          %span
-            =calendar_date_select_tag "report[after]", @report[:after], :year_range => 3.years.ago..1.years.from_now
-            %label{:for => 'report[after]'} Date From
-          %span
-            =calendar_date_select_tag "report[before]", @report[:before], :year_range => 3.years.ago..1.years.from_now
-            %label{:for => 'report[before]'} Date To
-          %p.instruct Leave one or both blank to search without date constraints.
-      %li 
-        =submit_tag "Update"
+-form_tag report_path(:action => 'visits'), :method => :get do
+  %ul
+    =labeled_input 'Date Range', :for => 'date_from' do
+      -capture do
+        %span
+          =calendar_date_select_tag "report[after]", @report[:after], :year_range => 3.years.ago..1.years.from_now
+          %label{:for => 'report[after]'} Date From
+        %span
+          =calendar_date_select_tag "report[before]", @report[:before], :year_range => 3.years.ago..1.years.from_now
+          %label{:for => 'report[before]'} Date To
+        %p.instruct Leave one or both blank to search without date constraints.
+    %li
+      =submit_tag "Update"
+
 %div.section
   -if @visits.empty?
     %div.list_status No visits for date range.
@@ -32,9 +32,9 @@
         %tr{:class => cycle('odd','even')}
           %td{:style => 'width:200px;'}
             =link_to(visit.person.full_name, person_path(:id => visit.person))
-          %td 
+          %td
             = visit.person.staff? ? 'Staff' : 'Patron'
-          %td 
+          %td
             = visit.volunteer?
           %td
             = datetime_long(visit.arrived_at)

--- a/app/views/reports/visits.html.haml
+++ b/app/views/reports/visits.html.haml
@@ -8,10 +8,10 @@
       =labeled_input 'Date Range', :for => 'date_from' do
         -capture do
           %span
-            =calendar_date_select_tag "report[after]", @report[:after], :year_range => 3.years.ago..1.years.from_now
+            =calendar_date_select_tag "report[after]", @report[:after], :year_range => 10.years.ago..1.years.from_now
             %label{:for => 'report[after]'} Date From
           %span
-            =calendar_date_select_tag "report[before]", @report[:before], :year_range => 3.years.ago..1.years.from_now
+            =calendar_date_select_tag "report[before]", @report[:before], :year_range => 10.years.ago..1.years.from_now
             %label{:for => 'report[before]'} Date To
           %p.instruct Leave one or both blank to search without date constraints.
       %li

--- a/app/views/services/edit.html.haml
+++ b/app/views/services/edit.html.haml
@@ -1,10 +1,11 @@
-%h1
-  =link_to @person.full_name, person_path(:id => @person)
-  = " : "
-  =link_to 'Services', services_path(:person_id => @person)
-  = " : Edit"
+%div.flex-column
 
--form_for @service, :url => service_path do |f|
-  =error_messages_for :service
-  =render :partial => 'services/form', :object => f
+  %h1
+    =link_to @person.full_name, person_path(:id => @person)
+    = " : "
+    =link_to 'Services', services_path(:person_id => @person)
+    = " : Edit"
 
+  -form_for @service, :url => service_path do |f|
+    =error_messages_for :service
+    =render :partial => 'services/form', :object => f

--- a/app/views/services/index.html.haml
+++ b/app/views/services/index.html.haml
@@ -1,29 +1,32 @@
-%h1
-  =link_to @person.full_name, person_path(:id => @person)
-  = " : Services"
+%div.flex-fullwidth
 
-=link_to 'New service', new_service_path
+  %h1
+    =link_to @person.full_name, person_path(:id => @person)
+    = " : Services"
 
-%table
-  %tr
-    %th Service type
-    %th Start date
-    %th End date
-    %th Paid
-    %th Volunteered
-    %th Note
-  -for service in @services
-    %tr{:class => cycle('odd','even')}
-      %td= service.service_type.name
-      %td= service.start_date
-      %td= service.end_date
-      %td= service.paid
-      %td= service.volunteered
-      %td.note= note_text(service.note)
-      %td= link_to 'Show', service_path(:id => service)
-      %td= link_to 'Edit', edit_service_path(:id => service)
-      %td= link_to 'Remove', service_path(:id => service), :confirm => 'Are you sure?', :method => :delete
-  -if @services.next_page? || @services.previous_page?
-    %tr.list_controls
-      %td{:colspan => 9}
-        .paginating_links More: #{paginating_links(@services)}
+  =link_to 'New service', new_service_path
+
+  %table
+    %tr
+      %th Service type
+      %th Start date
+      %th End date
+      %th Paid
+      %th Volunteered
+      %th Note
+      %th{:colspan => 3}
+    -for service in @services
+      %tr{:class => cycle('odd','even')}
+        %td= service.service_type.name
+        %td= service.start_date
+        %td= service.end_date
+        %td= service.paid
+        %td= service.volunteered
+        %td.note= note_text(service.note)
+        %td= link_to 'Show', service_path(:id => service)
+        %td= link_to 'Edit', edit_service_path(:id => service)
+        %td= link_to 'Remove', service_path(:id => service), :confirm => 'Are you sure?', :method => :delete
+    -if @services.next_page? || @services.previous_page?
+      %tr.list_controls
+        %td{:colspan => 9}
+          .paginating_links More: #{paginating_links(@services)}

--- a/app/views/services/new.html.haml
+++ b/app/views/services/new.html.haml
@@ -1,20 +1,11 @@
-%h1
-  =link_to @person.full_name, person_path(:id => @person)
-  = " : "
-  =link_to 'Services', services_path(:person_id => @person)
-  = " : New"
+%div.flex-column
 
--form_for @service do |f|
-  =error_messages_for :service
-  =render :partial => 'services/form', :object => f
+  %h1
+    =link_to @person.full_name, person_path(:id => @person)
+    = " : "
+    =link_to 'Services', services_path(:person_id => @person)
+    = " : New"
 
--# Original:
-
--#   0: h1 do
--#   1:   link_to @person.full_name, person_path(:id => @person)
--#   2:   text ' : '
--#   3:   link_to 'Services', services_path(:person_id => @person)
--#   4:   text ' : New'
--#   8: form_for @service do |f|
--#   9:   error_messages_for :service
--#  10:   service_form_fields(f)
+  -form_for @service do |f|
+    =error_messages_for :service
+    =render :partial => 'services/form', :object => f

--- a/app/views/services/show.html.haml
+++ b/app/views/services/show.html.haml
@@ -1,16 +1,18 @@
-%h1
-  =link_to @person.full_name, person_path(:id => @person)
-  = " : "
-  =link_to 'Services', services_path(:person_id => @person)
-  = " : Detail"
+%div.flex-column
 
-%ul
-  =labeled_value 'Service type', @service.service_type.name
-  =labeled_value 'Start date', @service.start_date
-  =labeled_value 'End date', @service.end_date
-  =labeled_value 'Paid', @service.paid
-  =labeled_value 'Volunteered', @service.volunteered
-  =labeled_value 'Note', note_text(@service.note)
-  =userstamp_labeled_values @service
+  %h1
+    =link_to @person.full_name, person_path(:id => @person)
+    = " : "
+    =link_to 'Services', services_path(:person_id => @person)
+    = " : Detail"
 
-=link_to 'Edit', edit_service_path(:id => @service)
+  %ul
+    =labeled_value 'Service type', @service.service_type.name
+    =labeled_value 'Start date', @service.start_date
+    =labeled_value 'End date', @service.end_date
+    =labeled_value 'Paid', @service.paid
+    =labeled_value 'Volunteered', @service.volunteered
+    =labeled_value 'Note', note_text(@service.note)
+    =userstamp_labeled_values @service
+
+  =link_to 'Edit', edit_service_path(:id => @service)

--- a/app/views/sessions/new.html.haml
+++ b/app/views/sessions/new.html.haml
@@ -1,17 +1,19 @@
-%h1 Log In
+%div.flex-column
 
--form_tag session_path do
-  %ul
-    =labeled_input 'Login', :for => :login do
-      -capture do
-        =text_field_tag 'login'
-    =labeled_input 'Password', :for => :password do
-      -capture do
-        =password_field_tag 'password'
-    %li
-      =check_box_tag('remember_me')
-      %label.choice{:for => 'remember_me'} Remember me
-    %li
-      =submit_tag 'Log in'
-    %li
-      =link_to 'Forgot username or password?', forgot_path
+  %h1 Log In
+
+  -form_tag session_path do
+    %ul
+      =labeled_input 'Login', :for => :login do
+        -capture do
+          =text_field_tag 'login'
+      =labeled_input 'Password', :for => :password do
+        -capture do
+          =password_field_tag 'password'
+      %li
+        =check_box_tag('remember_me')
+        %label.choice.remember_me{:for => 'remember_me'} Remember me
+      %li
+        =submit_tag 'Log in'
+      %li
+        =link_to 'Forgot username or password?', forgot_path

--- a/app/views/sessions/new.html.haml
+++ b/app/views/sessions/new.html.haml
@@ -6,7 +6,7 @@
     %ul
       =labeled_input 'Login', :for => :login do
         -capture do
-          =text_field_tag 'login'
+          =text_field_tag 'login', '', :autocapitalize => 'none'
       =labeled_input 'Password', :for => :password do
         -capture do
           =password_field_tag 'password'

--- a/app/views/taggings/_index.html.haml
+++ b/app/views/taggings/_index.html.haml
@@ -16,7 +16,7 @@
           =link_to 'x', tagging_path(:organization_key => @organization.key, :person_id => person, :id => tagging.id), :class => 'delete'
       %li.form
         -form_for :taggings, :url => taggings_path(:organization_key => @organization.key, :person_id => person) do |f|
-          %select
+          %select.css_select
             %option{:value => ''} Choose tag
             -for tag in @organization.tags - person.tags
               %option{:value => tag.name}= tag.name

--- a/app/views/tags/show.html.haml
+++ b/app/views/tags/show.html.haml
@@ -10,7 +10,7 @@
       });
     })(jQuery);
 
-%div.column{:style => 'width: 650px; margin-right: 40px;'}
+%div{:style => 'width: 650px; margin-right: 40px;'}
 
   %h1 Tag : #{@tag}
 
@@ -46,8 +46,8 @@
           -if @people.next_page? || @people.previous_page?
             %div.paginating_links
               More: #{paginating_links(@people)}
-            
-%div.column{:style => 'width: 200px;'}
+
+%div{:style => 'width: 200px;'}
   %h2 All Tags
   %ul
     -for tag in @organization.tags

--- a/app/views/users/_form.html.haml
+++ b/app/views/users/_form.html.haml
@@ -3,7 +3,7 @@
     =form.text_field :name
 =labeled_input 'Email', :for => :email do
   -capture do
-    =form.text_field :email
+    =form.text_field :email, :autocapitalize => 'none'
 =labeled_input 'Login', :for => :login do
   -capture do
     =form.text_field :login

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -1,6 +1,8 @@
-%h1 Editing user
-=error_messages_for :user
--form_for @user do |f|
-  %ul
-    = render :partial => 'users/form', :object => f
-    %li= f.submit 'Update'
+%div.flex-column
+
+  %h1 Editing user
+  =error_messages_for :user
+  -form_for @user do |f|
+    %ul
+      = render :partial => 'users/form', :object => f
+      %li= f.submit 'Update'

--- a/app/views/users/forgot.html.haml
+++ b/app/views/users/forgot.html.haml
@@ -1,5 +1,7 @@
-%h1 User: Send password reset
-%div.column.left
+%div.flex-column
+
+  %h1 User: Send password reset
+
   -form_for @user, :url => forgot_path do |f|
     =error_messages_for :user
     %ul
@@ -7,5 +9,5 @@
         -capture do
           = f.text_field(:email)
           %p.instruct Enter the email address you signed up with. You will get an email with a link to reset your password.
-      %li 
+      %li
         =submit_tag 'Submit'

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -1,20 +1,22 @@
-%h1 Listing users
-%table
-  %tr
-    %th Name
-    %th Email
-    %th Login
-    %th Activated at
-    %th Created at
-  -for user in @users
-    %tr{:class => cycle('odd','even')}
-      %td= user.name
-      %td= user.email
-      %td= user.login
-      %td= user.activated_at.nil? ? 'Not yet activated' : datetime_short(user.activated_at)
-      %td= datetime_short(user.created_at)
-      %td= link_to 'Show', user
-      %td= link_to 'Edit', edit_user_path(user)
-      %td= link_to 'Remove', user, :confirm => 'Are you sure?', :method => :delete
-%br
-=link_to 'New user', new_user_path
+%div.flex-fullwidth
+
+  %h1 Listing users
+  %table
+    %tr
+      %th Name
+      %th Email
+      %th Login
+      %th Activated at
+      %th Created at
+    -for user in @users
+      %tr{:class => cycle('odd','even')}
+        %td= user.name
+        %td= user.email
+        %td= user.login
+        %td= user.activated_at.nil? ? 'Not yet activated' : datetime_short(user.activated_at)
+        %td= datetime_short(user.created_at)
+        %td= link_to 'Show', user
+        %td= link_to 'Edit', edit_user_path(user)
+        %td= link_to 'Remove', user, :confirm => 'Are you sure?', :method => :delete
+  %br
+  =link_to 'New user', new_user_path

--- a/app/views/users/new.html.haml
+++ b/app/views/users/new.html.haml
@@ -1,6 +1,8 @@
-%h1 New user
-=error_messages_for :user
--form_for @user do |f|
-  %ul
-    = render :partial => 'users/form', :object => f
-    %li= f.submit 'Sign Up'
+%div.flex-column
+
+  %h1 New user
+  =error_messages_for :user
+  -form_for @user do |f|
+    %ul
+      = render :partial => 'users/form', :object => f
+      %li= f.submit 'Sign Up'

--- a/app/views/users/reset.html.haml
+++ b/app/views/users/reset.html.haml
@@ -1,10 +1,12 @@
-%h1 User: Reset password for #{@user.email}
-=error_messages_for :user
--form_for @user, :url => reset_path(:reset_code => params[:reset_code]), :html => { :method => :post } do |f|
-  =labeled_input 'Password', :for => :password do
-    -capture do
-      =f.password_field :password
-  =labeled_input 'Confirm Password', :for => :password_confirmation do
-    -capture do
-      =f.password_field :password_confirmation
-  %li= submit_tag 'Reset'
+%div.flex-column
+
+  %h1 User: Reset password for #{@user.email}
+  =error_messages_for :user
+  -form_for @user, :url => reset_path(:reset_code => params[:reset_code]), :html => { :method => :post } do |f|
+    =labeled_input 'Password', :for => :password do
+      -capture do
+        =f.password_field :password
+    =labeled_input 'Confirm Password', :for => :password_confirmation do
+      -capture do
+        =f.password_field :password_confirmation
+    %li= submit_tag 'Reset'

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -1,9 +1,10 @@
-%h1 #{@user.name} Profile
-%ul
-  =labeled_value 'Name', @user.name
-  =labeled_value 'Email', @user.email
-  =labeled_value 'Login', @user.login
-  =labeled_value 'Activated at', @user.activated_at.nil? ? 'Not yet activated' : datetime_long(@user.activated_at)
--if permit?('owner of :user')
-  =link_to 'Edit', edit_user_path(@user)
+%div.flex-column
 
+  %h1 #{@user.name} Profile
+  %ul
+    =labeled_value 'Name', @user.name
+    =labeled_value 'Email', @user.email
+    =labeled_value 'Login', @user.login
+    =labeled_value 'Activated at', @user.activated_at.nil? ? 'Not yet activated' : datetime_long(@user.activated_at)
+  -if permit?('owner of :user')
+    =link_to 'Edit', edit_user_path(@user)

--- a/app/views/visits/_person_search.html.haml
+++ b/app/views/visits/_person_search.html.haml
@@ -3,7 +3,7 @@
   %div.form
     %label.desc{:style => 'float:left;'} Name
     =image_tag 'spinner.gif', :id => 'search_status', :style => 'display:none;'
-    =text_field_with_auto_complete :person, :full_name, { :onfocus => "this.select()" }, { :url => auto_complete_for_person_full_name_people_path(:organization_key => @organization.key), :method => :get, :min_chars => 2, :indicator => 'search_status', :after_update_element => "function(element, value) { window.location = $(value).readAttribute('url'); }" }
+    =text_field_with_auto_complete :person, :full_name, { :onfocus => "this.select()", :autocomplete => 'off' }, { :url => auto_complete_for_person_full_name_people_path(:organization_key => @organization.key), :method => :get, :min_chars => 2, :indicator => 'search_status', :after_update_element => "function(element, value) { window.location = $(value).readAttribute('url'); }" }
   %p
     Start typing to find a person or
     = "#{link_to "add a new person", new_person_path(:organization_key => @organization.key)}."

--- a/app/views/visits/day.html.haml
+++ b/app/views/visits/day.html.haml
@@ -17,19 +17,25 @@
       %table.visits
         -reset_cycle
         -for visit in @groups[group[:key]]
-          %tr{:class => cycle('odd','even')}
-            %td{:style => 'width:200px;'}
+          - cycle_class = cycle('odd','even')
+          - if visit.note and visit.note.text
+            - note_class = 'followed_by_note'
+          %tr{:class => [cycle_class, note_class]}
+            %td.full_name
               =link_to(visit.person.full_name, person_path(:id => visit.person))
-            %td
+            %td.person_type
               = visit.person.person_type
             %td.time
               = time_short(visit.arrived_at)
-            %td.note{:style => 'width:400px;'}
-              = note_text(visit.note)
-            %td{:style => 'width:30px;'}
+            %td.action.edit
               =link_to 'Edit', edit_visit_path(:person_id => visit.person, :id => visit, :destination => day_visits_path)
-            %td 
+            %td.action.remove
               =link_to 'Remove', visit_path(:person_id => visit.person, :id => visit, :destination => day_visits_path), :method => :delete
+          - if visit.note
+            %tr{:class => cycle_class}
+              %td
+              %td.note{:colspan => 4}
+                = note_text(visit.note)
 
 %div.section
   %p

--- a/app/views/visits/day.html.haml
+++ b/app/views/visits/day.html.haml
@@ -1,45 +1,47 @@
 -if @day == Time.zone.today
-  = render :partial => 'visits/person_search'
+  %div.flex-column
+    = render :partial => 'visits/person_search'
 
-%div.section.visits!
-  -if @day == Time.zone.today
-    %h2 In the Shop Today!
-  -else
-    %h2 In the Shop on #{date_long(@day)}
-  -if @visits.empty?
-    %p.list_status No visits for #{@day.to_s(:db)}.
-  -else
-    %p.list_status #{@visits.size} visitors.
-    -[{:key => :patrons, :label => 'Visiting'}, {:key => :volunteers, :label => 'Volunteering'}].each do |group|
-      -if @groups[group[:key]].empty?
-        -next
-      %h3 #{@groups[group[:key]].size} #{group[:label]}
-      %table.visits
-        -reset_cycle
-        -for visit in @groups[group[:key]]
-          - cycle_class = cycle('odd','even')
-          - if visit.note and visit.note.text
-            - note_class = 'followed_by_note'
-          %tr{:class => [cycle_class, note_class]}
-            %td.full_name
-              =link_to(visit.person.full_name, person_path(:id => visit.person))
-            %td.person_type
-              = visit.person.person_type
-            %td.time
-              = time_short(visit.arrived_at)
-            %td.action.edit
-              =link_to 'Edit', edit_visit_path(:person_id => visit.person, :id => visit, :destination => day_visits_path)
-            %td.action.remove
-              =link_to 'Remove', visit_path(:person_id => visit.person, :id => visit, :destination => day_visits_path), :method => :delete
-          - if visit.note
-            %tr{:class => cycle_class}
-              %td
-              %td.note{:colspan => 4}
-                = note_text(visit.note)
+%div.flex-fullwidth
+  %div.section.visits!
+    -if @day == Time.zone.today
+      %h2 In the Shop Today!
+    -else
+      %h2 In the Shop on #{date_long(@day)}
+    -if @visits.empty?
+      %p.list_status No visits for #{@day.to_s(:db)}.
+    -else
+      %p.list_status #{@visits.size} visitors.
+      -[{:key => :patrons, :label => 'Visiting'}, {:key => :volunteers, :label => 'Volunteering'}].each do |group|
+        -if @groups[group[:key]].empty?
+          -next
+        %h3 #{@groups[group[:key]].size} #{group[:label]}
+        %table.visits
+          -reset_cycle
+          -for visit in @groups[group[:key]]
+            - cycle_class = cycle('odd','even')
+            - if visit.note and visit.note.text
+              - note_class = 'followed_by_note'
+            %tr{:class => [cycle_class, note_class]}
+              %td.full_name
+                =link_to(visit.person.full_name, person_path(:id => visit.person))
+              %td.person_type
+                = visit.person.person_type
+              %td.time
+                = time_short(visit.arrived_at)
+              %td.action.edit
+                =link_to 'Edit', edit_visit_path(:person_id => visit.person, :id => visit, :destination => day_visits_path)
+              %td.action.remove
+                =link_to 'Remove', visit_path(:person_id => visit.person, :id => visit, :destination => day_visits_path), :method => :delete
+            - if visit.note
+              %tr{:class => cycle_class}
+                %td
+                %td.note{:colspan => 4}
+                  = note_text(visit.note)
 
-%div.section
-  %p
-    See #{link_to "previous", day_visits_path(@day.yesterday)}
-    -unless @day == Time.zone.today 
-      or #{link_to "next", day_visits_path(@day.tomorrow)}
-    day.
+  %div.section
+    %p
+      See #{link_to "previous", day_visits_path(@day.yesterday)}
+      -unless @day == Time.zone.today
+        or #{link_to "next", day_visits_path(@day.tomorrow)}
+      day.

--- a/app/views/visits/day.html.haml
+++ b/app/views/visits/day.html.haml
@@ -20,6 +20,7 @@
           -reset_cycle
           -for visit in @groups[group[:key]]
             - cycle_class = cycle('odd','even')
+            - note_class = nil
             - if visit.note and visit.note.text
               - note_class = 'followed_by_note'
             %tr{:class => [cycle_class, note_class]}

--- a/app/views/visits/edit.html.haml
+++ b/app/views/visits/edit.html.haml
@@ -1,15 +1,16 @@
-%h1
-  =link_to @person.full_name, person_path(:id => @person)
-  = ' : '
-  =link_to 'Visits', visits_path(:person_id => @person)
-  = ' : Edit'
+%div.flex-fullwidth
+  %h1
+    =link_to @person.full_name, person_path(:id => @person)
+    = ' : '
+    =link_to 'Visits', visits_path(:person_id => @person)
+    = ' : Edit'
 
--form_for @visit, :url => visit_path do |f|
-  =error_messages_for :visit
-  -if params[:destination]
-    =hidden_field_tag :destination, params[:destination]
-  =render :partial => 'visits/form', :object => f, :locals => { :visit => @visit }
-  :javascript
-    Event.observe(window, 'load', function() {
-      $('note_text').focus();
-    });
+  -form_for @visit, :url => visit_path do |f|
+    =error_messages_for :visit
+    -if params[:destination]
+      =hidden_field_tag :destination, params[:destination]
+    =render :partial => 'visits/form', :object => f, :locals => { :visit => @visit }
+    :javascript
+      Event.observe(window, 'load', function() {
+        $('note_text').focus();
+      });

--- a/app/views/visits/index.html.haml
+++ b/app/views/visits/index.html.haml
@@ -1,25 +1,27 @@
-%h1
-  =link_to @person.full_name, person_path(:id => @person)
-  = " : Visits"
+%div.flex-fullwidth
+  %h1
+    =link_to @person.full_name, person_path(:id => @person)
+    = " : Visits"
 
-=link_to 'New visit', new_visit_path
+  =link_to 'New visit', new_visit_path
 
-%table
-  %tr
-    %th When
-    %th Datetime
-    %th Volunteer
-    %th Note
-  -for visit in @visits
-    %tr{:class => cycle('odd','even')}
-      %td #{time_ago_in_words(visit.arrived_at)} ago
-      %td= datetime_long(visit.arrived_at)
-      %td= visit.volunteer?
-      %td.note{:style => 'width:360px;'}= note_text(visit.note)
-      %td= link_to 'Show', visit_path(:id => visit)
-      %td= link_to 'Edit', edit_visit_path(:id => visit)
-      %td= link_to 'Remove', visit_path(:id => visit), :confirm => 'Are you sure?', :method => :delete
-  -if @visits.next_page? || @visits.previous_page?
-    %tr.list_controls
-      %td{:colspan => 7}
-        %div.paginating_links More: #{paginating_links(@visits)}
+  %table
+    %tr
+      %th When
+      %th Datetime
+      %th Volunteer
+      %th Note
+      %th{:colspan => 3}
+    -for visit in @visits
+      %tr{:class => cycle('odd','even')}
+        %td #{time_ago_in_words(visit.arrived_at)} ago
+        %td= datetime_long(visit.arrived_at)
+        %td= visit.volunteer?
+        %td.note{:style => 'width:360px;'}= note_text(visit.note)
+        %td= link_to 'Show', visit_path(:id => visit)
+        %td= link_to 'Edit', edit_visit_path(:id => visit)
+        %td= link_to 'Remove', visit_path(:id => visit), :confirm => 'Are you sure?', :method => :delete
+    -if @visits.next_page? || @visits.previous_page?
+      %tr.list_controls
+        %td{:colspan => 7}
+          %div.paginating_links More: #{paginating_links(@visits)}

--- a/app/views/visits/new.html.haml
+++ b/app/views/visits/new.html.haml
@@ -1,9 +1,10 @@
-%h1
-  =link_to @person.full_name, person_path(:id => @person)
-  = ' : '
-  =link_to 'Visits', visits_path(:person_id => @person)
-  = ' : New'
+%div.flex-column
+  %h1
+    =link_to @person.full_name, person_path(:id => @person)
+    = ' : '
+    =link_to 'Visits', visits_path(:person_id => @person)
+    = ' : New'
 
--form_for @visit do |f|
-  =error_messages_for :visit
-  =render :partial => 'visits/form', :object => f, :locals => { :visit => @visit }
+  -form_for @visit do |f|
+    =error_messages_for :visit
+    =render :partial => 'visits/form', :object => f, :locals => { :visit => @visit }

--- a/app/views/visits/show.html.haml
+++ b/app/views/visits/show.html.haml
@@ -1,13 +1,14 @@
-%h1
-  =link_to @person.full_name, person_path(:id => @person)
-  = ' : '
-  =link_to 'Visits', visits_path(:person_id => @person)
-  = ' : Detail'
-%ul
-  =labeled_value 'Datetime', datetime_long(@visit.arrived_at)
-  =labeled_value 'Volunteer', @visit.volunteer?
-  =labeled_value 'Note', note_text(@visit.note)
-  =labeled_value 'Person', @visit.person.full_name
-  -userstamp_labeled_values @visit
-  
-=link_to 'Edit', edit_visit_path(:id => @visit)
+%div.flex-fullwidth
+  %h1
+    =link_to @person.full_name, person_path(:id => @person)
+    = ' : '
+    =link_to 'Visits', visits_path(:person_id => @person)
+    = ' : Detail'
+  %ul
+    =labeled_value 'Datetime', datetime_long(@visit.arrived_at)
+    =labeled_value 'Volunteer', @visit.volunteer?
+    =labeled_value 'Note', note_text(@visit.note)
+    =labeled_value 'Person', @visit.person.full_name
+    -userstamp_labeled_values @visit
+
+  =link_to 'Edit', edit_visit_path(:id => @visit)

--- a/flexbox.css
+++ b/flexbox.css
@@ -1,0 +1,44 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+.flex-container {
+  background-color: lightgray;
+  padding: 10px;
+  max-width: 955px;
+  display: flex;
+  justify-content: flex-start;
+  flex-wrap: wrap;
+}
+
+.item {
+  background-color: white;
+  height: 100px;
+  margin: 5px;
+  padding: 20px;
+  font-size: 30px;
+  border-radius: 4px;
+  text-align: center;
+}
+
+.flex-column {
+  width: 50%;
+  min-width: 380px;
+}
+
+@media (max-width: 400px) {
+  .flex-column {
+    width: 100%;
+    min-width: inherit;
+  }
+}
+
+.flex-fullwidth {
+  width: 100%;
+}
+
+.A {
+  height: 200px;
+}

--- a/flexbox.html
+++ b/flexbox.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang='en'>
+  <head>
+    <meta charset='UTF-8'/>
+    <meta name='viewport' content='initial-scale=1,maximum-scale=1,user-scalable=no'/>
+    <title>Some Web Page</title>
+    <link rel='stylesheet' href='flexbox.css'/>
+  </head>
+  <body>
+    <div class='flex-container'>
+      <div class='flex-column'>
+        <div class="item A">A</div>
+      </div>
+      <div class='flex-column'>
+        <div class="item B">B</div>
+      </div>
+      <div class='flex-column'>
+        <div class="item C">C</div>
+      </div>
+      <div class='flex-fullwidth'>
+        <div class="item D">D</div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/public/stylesheets/application.css
+++ b/public/stylesheets/application.css
@@ -182,6 +182,9 @@ table.visits {
 
 tr.even, li.even { background: #ffffff; }
 tr.odd, li.odd  { background: lightcyan; }
+tr.followed_by_note {
+  border-bottom: none;
+}
 
 td.full_name {
   white-space: nowrap;

--- a/public/stylesheets/application.css
+++ b/public/stylesheets/application.css
@@ -1,29 +1,50 @@
-/** Basic two column responsive layout **/
-
-.column {
-  float: left;
-  width: 50%;
-}
-
-/* Clear floats after the columns */
-.row:after {
-  content: "";
-  display: table;
-  clear: both;
-}
-
-@media screen and (max-width: 600px) {
-  .column {
-    width: 100%;
-  }
-}
-
 /** Top Level Layout **/
 
 #application{
   max-width:955px;
   text-align: left;
   margin: 0 auto;
+}
+
+#application_body {
+  background: white;
+  padding: 26px;
+  display: grid;
+  grid-template-columns: 50% 50%;
+  grid-template-rows: auto;
+  justify-items: center;
+  grid-template-areas:
+          "column column"
+          "column-left column-right"
+          "footer footer";
+}
+
+@media (max-width: 800px) {
+  #application_body {
+    grid-template-columns: auto;
+    grid-template-rows: auto auto;
+    grid-template-areas:
+            'column'
+            'column-left'
+            'column-right';
+  }
+}
+
+.column {
+  grid-area: column;
+  padding: 6px 26px 6px 26px;
+}
+
+.column-left {
+  grid-area: column-left;
+  width: 100%;
+  padding: 0 26px 0 26px;
+}
+
+.column-right {
+  grid-area: column-right;
+  width: 100%;
+  padding: 0 26px 0 26px;
 }
 
 #footer {
@@ -88,15 +109,6 @@
   color: #555;
 }
 
-#application_body {
-  background: white;
-  padding: 26px;
-}
-
-#application_body {
-  /** background: url('../images/body_bg.png') repeat-y; **/
-}
-
 #application_footer {
   background: url('../images/footer_bg.png') no-repeat;
   font-style: italic;
@@ -122,8 +134,8 @@
   color: #555;
 }
 
-#user_status .log_out {
-  padding-left: 10px;
+#user_status span {
+  padding: 0 5px;
 }
 
 #notice {

--- a/public/stylesheets/application.css
+++ b/public/stylesheets/application.css
@@ -31,7 +31,7 @@
   width: 100%;
 }
 
-@media (max-width: 400px) {
+@media (max-width: 800px) {
   .flex-column {
     width: 100%;
     min-width: inherit;
@@ -129,6 +129,7 @@
   margin: 14px 0 0 14px;
 }
 
+#application_header h2,
 #application_header h2 a
 {
   color: white;
@@ -138,6 +139,12 @@
 ul.tabs {
   float:right;
   margin: 12px 12px -1px; /* -1px is a hack to hide bottom edge on mobile */
+}
+
+@media (max-width: 800px) {
+  ul.tabs {
+    float: inherit;
+  }
 }
 
 ul.tabs li {
@@ -231,6 +238,7 @@ div.left div.section {
   background: lightyellow;
   border: 1px solid tan;
   padding: 14px;
+  max-width: 360px;
 }
 
 /** visits/day **/

--- a/public/stylesheets/application.css
+++ b/public/stylesheets/application.css
@@ -43,7 +43,6 @@
 }
 
 #footer {
-  background: black;
   height: 100px;
 }
 
@@ -56,6 +55,7 @@
   align-items: center;
   color: white;
   font-size: 11px;
+  background: black;
 }
 
 @media (max-width: 800px) {
@@ -81,7 +81,7 @@
   /** brown **/ /** background: #663300; **/
   /** green **/ /** background: #99CC00; **/
   /** grey **/  /** background: #BBB; **/
-  /** darkgrey **/  background: dimgray; 
+  /** darkgrey **/  background: dimgray;
 }
 
 #application_header,

--- a/public/stylesheets/application.css
+++ b/public/stylesheets/application.css
@@ -1,7 +1,7 @@
 /** Top Level Layout **/
 
 #application{
-  max-width:955px;
+  max-width: 955px;
   text-align: left;
   margin: 0 auto;
 }
@@ -15,6 +15,13 @@
   justify-items: center;
   grid-template-areas:
           "column-left column-right";
+}
+
+#application_header_wrapper {
+  display: flex;
+  flex-direction: row-reverse;
+  justify-content: space-between;
+  background: dimgray;
 }
 
 @media (max-width: 800px) {
@@ -61,6 +68,10 @@
 @media (max-width: 800px) {
   #footer .body {
     flex-flow: column;
+  }
+
+  #application_header_wrapper {
+    flex-direction: column-reverse;
   }
 }
 
@@ -134,6 +145,7 @@
 #application_header {
   padding: 14px;
 }
+
 #application_header h2 {
   font-size: 20px;
 }

--- a/public/stylesheets/application.css
+++ b/public/stylesheets/application.css
@@ -17,13 +17,13 @@
 .flex-container {
   background-color: lightgray;
   display: flex;
-  justify-content: flex-start;
+  justify-content: space-between;
   flex-wrap: wrap;
 }
 
 
 .flex-column {
-  width: 50%;
+  width: 48%;
   min-width: 380px;
 }
 

--- a/public/stylesheets/application.css
+++ b/public/stylesheets/application.css
@@ -186,6 +186,10 @@ tr.followed_by_note {
   border-bottom: none;
 }
 
+tr.followed_by_note td {
+  padding-bottom: 0;
+}
+
 td.full_name {
   white-space: nowrap;
   width: 200px;

--- a/public/stylesheets/application.css
+++ b/public/stylesheets/application.css
@@ -59,6 +59,14 @@
   }
 }
 
+@media (min-width: 800px) {
+  .credit {
+    margin-left: auto;
+    position: relative;
+    left: -100px;
+  }
+}
+
 .footer-item {
   padding: 0 20px 16px 14px;
 }
@@ -137,31 +145,13 @@
 /** Application Navigation **/
 ul.tabs {
   float:right;
-  margin: 12px 12px -1px; /* -1px is a hack to hide bottom edge on mobile */
-}
-
-@media (max-width: 800px) {
-  ul.tabs {
-    float: inherit;
-  }
-
-  #footer .body {
-    flex-flow: column;
-  }
-}
-
-@media (min-width: 800px) {
-  .credit {
-    margin-left: auto;
-    position: relative;
-    left: -100px;
-  }
+  margin: 12px 12px 0;
 }
 
 ul.tabs li {
   float:left;
   font-size: 14px;
-  padding: 6px 14px 10px 14px;
+  padding: 6px 18px 10px 18px;
   color: white;
 }
 
@@ -175,6 +165,15 @@ ul.tabs li.selected a {
   color: #555;
 }
 
+@media (max-width: 800px) {
+  ul.tabs {
+    float: inherit;
+  }
+
+  ul.tabs li {
+    padding: 6px 14px 10px 14px;
+  }
+}
 
 .list_controls, .list_controls td {
   border: 1px solid tan;

--- a/public/stylesheets/application.css
+++ b/public/stylesheets/application.css
@@ -272,6 +272,12 @@ div.left div.section {
   font-size: 14px;
 }
 
+@media (max-width: 800px) {
+  div.auto_complete ul li {
+    padding: 8px 3px !important;
+  }
+}
+
 /** Base HTML Styling **/
 
 a {

--- a/public/stylesheets/application.css
+++ b/public/stylesheets/application.css
@@ -126,7 +126,7 @@
 /** Application Navigation **/
 ul.tabs {
   float:right;
-  margin: 12px 12px 0 0;
+  margin: 12px 12px 0;
 }
 
 ul.tabs li {

--- a/public/stylesheets/application.css
+++ b/public/stylesheets/application.css
@@ -298,6 +298,7 @@ input[type=submit]:hover {
 #application_body h1 {
   font-size: 24px;
   padding: 0 0 12px 0;
+  line-height: 1em;
 }
 
 #application_body h2 {

--- a/public/stylesheets/application.css
+++ b/public/stylesheets/application.css
@@ -247,6 +247,7 @@ div.left div.section {
   background: lightyellow;
   border: 1px solid tan;
   padding: 14px;
+  max-width: 360px;
 }
 
 #sign_in #person_full_name{

--- a/public/stylesheets/application.css
+++ b/public/stylesheets/application.css
@@ -54,6 +54,12 @@
   background: black;
 }
 
+@media (max-width: 800px) {
+  #footer .body {
+    flex-flow: column;
+  }
+}
+
 .footer-item {
   padding: 0 20px 16px 14px;
 }
@@ -64,31 +70,6 @@
 
 #footer #logo {
   font-size: 30px;
-}
-
-#application_nav {
-  /** brown **/ /** background: #663300; **/
-  /** green **/ /** background: #99CC00; **/
-  /** grey **/  /** background: #BBB; **/
-  /** darkgrey **/
-  background: dimgray;
-  display: flex;
-  flex-flow: row;
-  justify-content: space-between;
-  background: dimgray;
-  align-items: center;
-}
-
-#application_nav h2,
-#application_nav h2 a
-{
-  color: white;
-  padding-left: 14px;
-}
-
-#application_nav h2 a {
-  color: white;
-  padding: 14
 }
 
 #application_footer,
@@ -132,14 +113,30 @@
 
 /** Application Header **/
 
-#application_nav h2 {
+
+#application_header {
+  /** brown **/ /** background: #663300; **/
+  /** green **/ /** background: #99CC00; **/
+  /** grey **/  /** background: #BBB; **/
+  /** darkgrey **/
+  background: dimgray;
+}
+
+#application_header h2
+{
   font-size: 20px;
+  margin: 14px 0 0 14px;
+}
+
+#application_header h2 a
+{
+  color: white;
 }
 
 /** Application Navigation **/
 ul.tabs {
   float:right;
-  margin: 12px 12px 0;
+  margin: 12px 12px -1px; /* -1px is a hack to hide bottom edge on mobile */
 }
 
 ul.tabs li {
@@ -367,16 +364,4 @@ div.uploadStatus {
 
 div.progressBar {
   margin: 5px;
-}
-
-@media (max-width: 800px) {
-  #footer .body {
-    flex-flow: column;
-  }
-
-  #application_nav {
-    flex-flow: column;
-    align-items: start;
-    padding-top: 10px;
-  }
 }

--- a/public/stylesheets/application.css
+++ b/public/stylesheets/application.css
@@ -1,7 +1,27 @@
+/** Basic two column responsive layout **/
+
+.column {
+  float: left;
+  width: 50%;
+}
+
+/* Clear floats after the columns */
+.row:after {
+  content: "";
+  display: table;
+  clear: both;
+}
+
+@media screen and (max-width: 600px) {
+  .column {
+    width: 100%;
+  }
+}
+
 /** Top Level Layout **/
 
 #application{
-  width:955px;
+  max-width:955px;
   text-align: left;
   margin: 0 auto;
 }
@@ -12,7 +32,7 @@
 }
 
 #footer .body {
-  width:955px;
+  max-width:955px;
   text-align: left;
   margin: 0 auto;
   color: white;
@@ -156,17 +176,35 @@ ul.tabs li.selected a {
 
 table.visits {
   width: 100%;
-  table-layout:fixed;
+  table-layout:auto;
 }
 
 tr.even, li.even { background: #ffffff; }
 tr.odd, li.odd  { background: lightcyan; }
 
+td.full_name {
+  white-space: nowrap;
+  width: 200px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 td.note {
+  width: 400px;
   font-style: italic;
 }
 
+td.person_type {
+  width: 40px;
+}
+
 td.time {
+  white-space: nowrap;
+  text-align: right;
+}
+
+td.action.edit {
+  width: 50%;
   text-align: right;
 }
 

--- a/public/stylesheets/application.css
+++ b/public/stylesheets/application.css
@@ -143,6 +143,14 @@ ul.tabs {
   }
 }
 
+@media (min-width: 800px) {
+  .credit {
+    margin-left: auto;
+    position: relative;
+    left: -100px;
+  }
+}
+
 ul.tabs li {
   float:left;
   font-size: 14px;

--- a/public/stylesheets/application.css
+++ b/public/stylesheets/application.css
@@ -31,13 +31,6 @@
   width: 100%;
 }
 
-@media (max-width: 800px) {
-  .flex-column {
-    width: 100%;
-    min-width: inherit;
-  }
-}
-
 #footer {
   height: 100px;
 }
@@ -52,12 +45,6 @@
   color: white;
   font-size: 11px;
   background: black;
-}
-
-@media (max-width: 800px) {
-  #footer .body {
-    flex-flow: column;
-  }
 }
 
 .footer-item {
@@ -145,6 +132,15 @@ ul.tabs {
   ul.tabs {
     float: inherit;
   }
+
+  #footer .body {
+    flex-flow: column;
+  }
+
+  .flex-column {
+    width: 100%;
+    min-width: inherit;
+  }
 }
 
 ul.tabs li {
@@ -156,7 +152,6 @@ ul.tabs li {
 
 ul.tabs li a {
   color: white;
-
 }
 
 ul.tabs li.selected,

--- a/public/stylesheets/application.css
+++ b/public/stylesheets/application.css
@@ -1,18 +1,4 @@
-/** Top Level Layout **/
-
-#application {
-  max-width: 955px;
-  text-align: left;
-  margin: 0 auto;
-}
-
-#application_body {
-  background: white;
-  padding: 3%;
-}
-
-/** Layout styles **/
-
+/** Responsive 2 column layout collapses to single column at 800px screen width **/
 
 .flex-container {
   background-color: lightgray;
@@ -27,8 +13,28 @@
   min-width: 380px;
 }
 
+@media (max-width: 800px) {
+  .flex-column {
+    width: 100%;
+    min-width: inherit;
+  }
+}
+
 .flex-fullwidth {
   width: 100%;
+}
+
+/** Top Level Layout **/
+
+#application {
+  max-width: 955px;
+  text-align: left;
+  margin: 0 auto;
+}
+
+#application_body {
+  background: white;
+  padding: 3%;
 }
 
 #footer {
@@ -45,6 +51,12 @@
   color: white;
   font-size: 11px;
   background: black;
+}
+
+@media (max-width: 800px) {
+  #footer .body {
+    flex-flow: column;
+  }
 }
 
 .footer-item {
@@ -135,11 +147,6 @@ ul.tabs {
 
   #footer .body {
     flex-flow: column;
-  }
-
-  .flex-column {
-    width: 100%;
-    min-width: inherit;
   }
 }
 

--- a/public/stylesheets/application.css
+++ b/public/stylesheets/application.css
@@ -9,27 +9,33 @@
 #application_body {
   background: white;
   padding: 26px;
-  display: grid;
-  grid-template-columns: 50% 50%;
-  grid-template-rows: auto;
-  justify-items: center;
-  grid-template-areas:
-          "column-left column-right";
 }
 
-.column {
-  grid-area: column;
-  padding: 6px 26px 6px 26px;
+/** Layout styles **/
+
+
+.flex-container {
+  background-color: lightgray;
+  display: flex;
+  justify-content: flex-start;
+  flex-wrap: wrap;
 }
 
-.column-left {
-  grid-area: column-left;
+
+.flex-column {
+  width: 50%;
+  min-width: 380px;
+}
+
+.flex-fullwidth {
   width: 100%;
 }
 
-.column-right {
-  grid-area: column-right;
-  width: 100%;
+@media (max-width: 400px) {
+  .flex-column {
+    width: 100%;
+    min-width: inherit;
+  }
 }
 
 #footer {
@@ -73,6 +79,13 @@
   align-items: center;
 }
 
+#application_nav h2,
+#application_nav h2 a
+{
+  color: white;
+  padding-left: 14px;
+}
+
 #application_nav h2 a {
   color: white;
   padding: 14
@@ -99,7 +112,7 @@
 
 #user_status {
   padding-top: 6px;
-  float:right;
+  float: right;
 }
 
 #user_status,
@@ -159,7 +172,7 @@ ul.tabs li.selected a {
 
 table.visits {
   width: 100%;
-  table-layout:auto;
+  table-layout: auto;
 }
 
 tr.even, li.even { background: #ffffff; }
@@ -196,11 +209,6 @@ div.section {
   clear: both;
 }
 
-div.column {
-  width: 420px;
-  float: left;
-}
-
 div.section div.left,
 div.left div.section {
   margin-right: 40px;
@@ -229,10 +237,6 @@ div.left div.section {
 
 /** visits/day **/
 
-#sign_in {
-  width: 400px;
-}
-
 #sign_in .form {
   background: lightyellow;
   border: 1px solid tan;
@@ -240,7 +244,7 @@ div.left div.section {
 }
 
 #sign_in #person_full_name{
-  width: 360px;
+  width: 100%;
   font-size: 14px;
 }
 
@@ -366,14 +370,6 @@ div.progressBar {
 }
 
 @media (max-width: 800px) {
-  #application_body {
-    grid-template-columns: auto;
-    grid-template-rows: auto auto;
-    grid-template-areas:
-            'column-left'
-            'column-right';
-  }
-
   #footer .body {
     flex-flow: column;
   }

--- a/public/stylesheets/application.css
+++ b/public/stylesheets/application.css
@@ -1,6 +1,6 @@
 /** Top Level Layout **/
 
-#application{
+#application {
   max-width: 955px;
   text-align: left;
   margin: 0 auto;
@@ -15,23 +15,6 @@
   justify-items: center;
   grid-template-areas:
           "column-left column-right";
-}
-
-#application_header_wrapper {
-  display: flex;
-  flex-direction: row-reverse;
-  justify-content: space-between;
-  background: dimgray;
-}
-
-@media (max-width: 800px) {
-  #application_body {
-    grid-template-columns: auto;
-    grid-template-rows: auto auto;
-    grid-template-areas:
-            'column-left'
-            'column-right';
-  }
 }
 
 .column {
@@ -65,16 +48,6 @@
   background: black;
 }
 
-@media (max-width: 800px) {
-  #footer .body {
-    flex-flow: column;
-  }
-
-  #application_header_wrapper {
-    flex-direction: column-reverse;
-  }
-}
-
 .footer-item {
   padding: 0 20px 16px 14px;
 }
@@ -87,18 +60,22 @@
   font-size: 30px;
 }
 
-#application_header,
 #application_nav {
   /** brown **/ /** background: #663300; **/
   /** green **/ /** background: #99CC00; **/
   /** grey **/  /** background: #BBB; **/
-  /** darkgrey **/  background: dimgray;
+  /** darkgrey **/
+  background: dimgray;
+  display: flex;
+  flex-flow: row;
+  justify-content: space-between;
+  background: dimgray;
+  align-items: center;
 }
 
-#application_header,
-#application_nav,
-#application_header a {
+#application_nav h2 a {
   color: white;
+  padding: 14
 }
 
 #application_footer,
@@ -142,11 +119,7 @@
 
 /** Application Header **/
 
-#application_header {
-  padding: 14px;
-}
-
-#application_header h2 {
+#application_nav h2 {
   font-size: 20px;
 }
 
@@ -165,6 +138,7 @@ ul.tabs li {
 
 ul.tabs li a {
   color: white;
+
 }
 
 ul.tabs li.selected,
@@ -389,4 +363,24 @@ div.uploadStatus {
 
 div.progressBar {
   margin: 5px;
+}
+
+@media (max-width: 800px) {
+  #application_body {
+    grid-template-columns: auto;
+    grid-template-rows: auto auto;
+    grid-template-areas:
+            'column-left'
+            'column-right';
+  }
+
+  #footer .body {
+    flex-flow: column;
+  }
+
+  #application_nav {
+    flex-flow: column;
+    align-items: start;
+    padding-top: 10px;
+  }
 }

--- a/public/stylesheets/application.css
+++ b/public/stylesheets/application.css
@@ -303,9 +303,9 @@ input[type=submit]:hover {
 }
 
 #application_body h1 {
-  font-size: 20px;
+  font-size: 24px;
   padding: 0 0 12px 0;
-  line-height: 1em;
+  line-height: 1.2em;
 }
 
 #application_body h2 {

--- a/public/stylesheets/application.css
+++ b/public/stylesheets/application.css
@@ -109,6 +109,7 @@
   background: lightcyan;
   color: #555;
   padding: 4px;
+  white-space: nowrap;
 }
 
 /** Application Header **/

--- a/public/stylesheets/application.css
+++ b/public/stylesheets/application.css
@@ -14,9 +14,7 @@
   grid-template-rows: auto;
   justify-items: center;
   grid-template-areas:
-          "column column"
-          "column-left column-right"
-          "footer footer";
+          "column-left column-right";
 }
 
 @media (max-width: 800px) {
@@ -24,7 +22,6 @@
     grid-template-columns: auto;
     grid-template-rows: auto auto;
     grid-template-areas:
-            'column'
             'column-left'
             'column-right';
   }
@@ -38,26 +35,37 @@
 .column-left {
   grid-area: column-left;
   width: 100%;
-  padding: 0 26px 0 26px;
 }
 
 .column-right {
   grid-area: column-right;
   width: 100%;
-  padding: 0 26px 0 26px;
 }
 
 #footer {
-  background:black;
+  background: black;
   height: 100px;
 }
 
 #footer .body {
-  max-width:955px;
-  text-align: left;
-  margin: 0 auto;
+  padding-left: 26px;
+  padding-top: 16px;
+  display: flex;
+  flex-flow: row;
+  justify-content: flex-start;
+  align-items: center;
   color: white;
   font-size: 11px;
+}
+
+@media (max-width: 800px) {
+  #footer .body {
+    flex-flow: column;
+  }
+}
+
+.footer-item {
+  padding: 0 20px 16px 14px;
 }
 
 #footer .body a {
@@ -65,29 +73,7 @@
 }
 
 #footer #logo {
-  float:left;
-  height: 60px;
-  text-align:center;
-  padding: 40px 20px 0 14px;
   font-size: 30px;
-}
-
-#footer ul {
-  float: left;
-  margin-top: 30px;
-  margin-left: 20px;
-}
-
-#footer .credit {
-  float: right;
-  padding-top: 14px;
-  padding-right: 40px;
-}
-
-#application_nav,
-#application_body,
-#application_footer {
-  clear:both;
 }
 
 #application_header,
@@ -113,7 +99,6 @@
   background: url('../images/footer_bg.png') no-repeat;
   font-style: italic;
   padding: 14px 14px 26px 14px;
-  clear: both;
 }
 
 /** Page Header **/
@@ -296,7 +281,6 @@ body {
   /** brown **/ /** background: #996633; **/
   /** green **/ /** background: #669900; **/
   /** grey **/  background: #EEEEEE;
-  text-align:center;
 }
 
 /** Explicitly style submit buttons to address iOS **/

--- a/public/stylesheets/application.css
+++ b/public/stylesheets/application.css
@@ -8,7 +8,7 @@
 
 #application_body {
   background: white;
-  padding: 26px;
+  padding: 3%;
 }
 
 /** Layout styles **/
@@ -213,7 +213,7 @@ td.action.edit {
 }
 
 div.section {
-  padding: 10px 0 10px 10px;
+  padding: 10px 0;
   clear: both;
 }
 

--- a/public/stylesheets/application.css
+++ b/public/stylesheets/application.css
@@ -299,6 +299,18 @@ body {
   text-align:center;
 }
 
+/** Explicitly style submit buttons to address iOS **/
+input[type=submit] {
+  -webkit-appearance: none;
+  padding: 2px 20px;
+  background-color: lightgray;
+  border-radius: 2px;
+}
+
+input[type=submit]:hover {
+  background-color: darkgray;
+}
+
 #application_body h1 {
   font-size: 24px;
   padding: 0 0 12px 0;

--- a/public/stylesheets/application.css
+++ b/public/stylesheets/application.css
@@ -290,18 +290,6 @@ body {
   /** grey **/  background: #EEEEEE;
 }
 
-/** Explicitly style submit buttons to address iOS **/
-input[type=submit] {
-  -webkit-appearance: none;
-  padding: 2px 20px;
-  background-color: lightgray;
-  border-radius: 2px;
-}
-
-input[type=submit]:hover {
-  background-color: darkgray;
-}
-
 #application_body h1 {
   font-size: 24px;
   padding: 0 0 12px 0;

--- a/public/stylesheets/form.css
+++ b/public/stylesheets/form.css
@@ -62,7 +62,7 @@ label.choice {
 }
 
 label.remember_me {
-  display: inline;
+  display: inline-block;
   padding: 0 4px;
   margin: 0;
 }
@@ -116,6 +116,13 @@ select.short {
 input.text,
 input.file {
   padding: 2px 0pt;
+}
+
+input[type=text],
+input[type=password],
+textarea {
+  border: 1px solid #ccc;
+  padding: 2px;
 }
 
 /** Rails Core error styles **/

--- a/public/stylesheets/form.css
+++ b/public/stylesheets/form.css
@@ -90,6 +90,14 @@ form p.instruct {
   z-index:1000;
 }
 
+
+@media (max-width: 800px) {
+  form p.instruct {
+    position: unset;
+    margin: 4px 0 0 0;
+  }
+}
+
 form span.option {
 	width:10%;
 }

--- a/public/stylesheets/form.css
+++ b/public/stylesheets/form.css
@@ -86,7 +86,7 @@ form p.instruct {
   padding:8px 10px 9px;
   position:absolute;
   top:0pt;
-  width:50%;
+  width:60%;
   z-index:1000;
 }
 

--- a/public/stylesheets/form.css
+++ b/public/stylesheets/form.css
@@ -158,7 +158,7 @@ all select elements and to match Freehub visual style
 **/
 
 /* class applies to select element itself, not a wrapper element */
-select {
+.css_select {
 	display: block;
 	line-height: 1.3;
 	padding: .3em 1.4em .2em .3em;
@@ -185,15 +185,15 @@ select {
 	background-size: .65em auto, 100%;
 }
 /* Hide arrow icon in IE browsers */
-select::-ms-expand {
+.css_select::-ms-expand {
 	display: none;
 }
 /* Hover style */
-select:hover {
+.css_select:hover {
 	border-color: #888;
 }
 /* Focus style */
-select:focus {
+.css_select:focus {
 	border-color: #aaa;
 	/* It'd be nice to use -webkit-focus-ring-color here but it doesn't work on box-shadow */
 	box-shadow: 0 0 1px 3px rgba(59, 153, 252, .7);
@@ -203,24 +203,24 @@ select:focus {
 }
 
 /* Set options to normal weight */
-select option {
+.css_select option {
 	font-weight:normal;
 }
 
 /* Support for rtl text, explicit support for Arabic and Hebrew */
-*[dir="rtl"] select, :root:lang(ar) select, :root:lang(iw) select {
+*[dir="rtl"] .css_select, :root:lang(ar) .css_select, :root:lang(iw) .css_select {
 	background-position: left .7em top 50%, 0 0;
 	padding: .6em .8em .5em 1.4em;
 }
 
 /* Disabled styles */
-select:disabled, select[aria-disabled=true] {
+.css_select:disabled, .css_select[aria-disabled=true] {
 	color: graytext;
 	background-image: url('data:image/svg+xml;charset=US-ASCII,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22292.4%22%20height%3D%22292.4%22%3E%3Cpath%20fill%3D%22graytext%22%20d%3D%22M287%2069.4a17.6%2017.6%200%200%200-13-5.4H18.4c-5%200-9.3%201.8-12.9%205.4A17.6%2017.6%200%200%200%200%2082.2c0%205%201.8%209.3%205.4%2012.9l128%20127.9c3.6%203.6%207.8%205.4%2012.8%205.4s9.2-1.8%2012.8-5.4L287%2095c3.5-3.5%205.4-7.8%205.4-12.8%200-5-1.9-9.2-5.5-12.8z%22%2F%3E%3C%2Fsvg%3E'),
 	  linear-gradient(to bottom, #ffffff 0%,#e5e5e5 100%);
 }
 
-select:disabled:hover, select[aria-disabled=true] {
+.css_select:disabled:hover, .css_select[aria-disabled=true] {
 	border-color: #aaa;
 }
 

--- a/public/stylesheets/form.css
+++ b/public/stylesheets/form.css
@@ -232,8 +232,8 @@ all select elements and to match Freehub visual style
   display: table;
 }
 
-#errorExplanation {
-  width: 400px;
+#errorExplanation { 
+  max-width: 380px;
   border: 2px solid #c00;
   margin-bottom: 20px;
   padding: 5px;

--- a/public/stylesheets/form.css
+++ b/public/stylesheets/form.css
@@ -95,6 +95,7 @@ form p.instruct {
   form p.instruct {
     position: unset;
     margin: 4px 0 0 0;
+    clear:both;
   }
 }
 

--- a/public/stylesheets/form.css
+++ b/public/stylesheets/form.css
@@ -131,8 +131,25 @@ input.file {
 input[type=text],
 input[type=password],
 textarea {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
   border: 1px solid #ccc;
   padding: 2px;
+  border-radius: 0;
+}
+
+/** Explicitly style submit buttons to address iOS **/
+input[type=submit] {
+  -webkit-appearance: none;
+  padding: 2px 20px;
+  background-color: lightgray;
+  border-color: lightgray;
+  border-radius: 2px;
+}
+
+input[type=submit]:hover {
+  background-color: darkgray;
 }
 
 /**
@@ -144,7 +161,7 @@ all select elements and to match Freehub visual style
 select {
 	display: block;
 	line-height: 1.3;
-	padding: .4em 1.4em .2em .2em;
+	padding: .3em 1.4em .2em .3em;
 	width: 100%;
 	max-width: 100%; /* useful when width is set to anything other than 100% */
 	box-sizing: border-box;

--- a/public/stylesheets/form.css
+++ b/public/stylesheets/form.css
@@ -113,7 +113,8 @@ input.radio {
 
 input.medium,
 select.medium {
-  width: 400px;
+  width: 100%;
+  max-width: 400px;
 }
 
 input.short,

--- a/public/stylesheets/form.css
+++ b/public/stylesheets/form.css
@@ -135,6 +135,78 @@ textarea {
   padding: 2px;
 }
 
+/**
+From https://www.filamentgroup.com/lab/select-css.html, modified to apply to
+all select elements and to match Freehub visual style
+**/
+
+/* class applies to select element itself, not a wrapper element */
+select {
+	display: block;
+	line-height: 1.3;
+	padding: .4em 1.4em .2em .2em;
+	width: 100%;
+	max-width: 100%; /* useful when width is set to anything other than 100% */
+	box-sizing: border-box;
+	margin: 0;
+	border: 1px solid #aaa;
+	border-radius: 4px;
+	-moz-appearance: none;
+	-webkit-appearance: none;
+	appearance: none;
+	background-color: #fff;
+	/* note: bg image below uses 2 urls. The first is an svg data uri for the arrow icon, and the second is the gradient.
+		for the icon, if you want to change the color, be sure to use `%23` instead of `#`, since it's a url. You can also swap in a different svg icon or an external image reference
+
+	*/
+	background-image: url('data:image/svg+xml;charset=US-ASCII,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22292.4%22%20height%3D%22292.4%22%3E%3Cpath%20fill%3D%22%23007CB2%22%20d%3D%22M287%2069.4a17.6%2017.6%200%200%200-13-5.4H18.4c-5%200-9.3%201.8-12.9%205.4A17.6%2017.6%200%200%200%200%2082.2c0%205%201.8%209.3%205.4%2012.9l128%20127.9c3.6%203.6%207.8%205.4%2012.8%205.4s9.2-1.8%2012.8-5.4L287%2095c3.5-3.5%205.4-7.8%205.4-12.8%200-5-1.9-9.2-5.5-12.8z%22%2F%3E%3C%2Fsvg%3E'),
+	  linear-gradient(to bottom, #ffffff 0%,#e5e5e5 100%);
+	background-repeat: no-repeat, repeat;
+	/* arrow icon position (1em from the right, 50% vertical) , then gradient position*/
+	background-position: right .7em top 50%, 0 0;
+	/* icon size, then gradient */
+	background-size: .65em auto, 100%;
+}
+/* Hide arrow icon in IE browsers */
+select::-ms-expand {
+	display: none;
+}
+/* Hover style */
+select:hover {
+	border-color: #888;
+}
+/* Focus style */
+select:focus {
+	border-color: #aaa;
+	/* It'd be nice to use -webkit-focus-ring-color here but it doesn't work on box-shadow */
+	box-shadow: 0 0 1px 3px rgba(59, 153, 252, .7);
+	box-shadow: 0 0 0 3px -moz-mac-focusring;
+	color: #222;
+	outline: none;
+}
+
+/* Set options to normal weight */
+select option {
+	font-weight:normal;
+}
+
+/* Support for rtl text, explicit support for Arabic and Hebrew */
+*[dir="rtl"] select, :root:lang(ar) select, :root:lang(iw) select {
+	background-position: left .7em top 50%, 0 0;
+	padding: .6em .8em .5em 1.4em;
+}
+
+/* Disabled styles */
+select:disabled, select[aria-disabled=true] {
+	color: graytext;
+	background-image: url('data:image/svg+xml;charset=US-ASCII,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22292.4%22%20height%3D%22292.4%22%3E%3Cpath%20fill%3D%22graytext%22%20d%3D%22M287%2069.4a17.6%2017.6%200%200%200-13-5.4H18.4c-5%200-9.3%201.8-12.9%205.4A17.6%2017.6%200%200%200%200%2082.2c0%205%201.8%209.3%205.4%2012.9l128%20127.9c3.6%203.6%207.8%205.4%2012.8%205.4s9.2-1.8%2012.8-5.4L287%2095c3.5-3.5%205.4-7.8%205.4-12.8%200-5-1.9-9.2-5.5-12.8z%22%2F%3E%3C%2Fsvg%3E'),
+	  linear-gradient(to bottom, #ffffff 0%,#e5e5e5 100%);
+}
+
+select:disabled:hover, select[aria-disabled=true] {
+	border-color: #aaa;
+}
+
 /** Rails Core error styles **/
 
 .fieldWithErrors {

--- a/public/stylesheets/form.css
+++ b/public/stylesheets/form.css
@@ -61,6 +61,12 @@ label.choice {
   width:90%;
 }
 
+label.remember_me {
+  display: inline;
+  padding: 0 4px;
+  margin: 0;
+}
+
 form .req {
   color: red !important;
   font-size: 14px;

--- a/public/stylesheets/form.css
+++ b/public/stylesheets/form.css
@@ -143,13 +143,13 @@ textarea {
 input[type=submit] {
   -webkit-appearance: none;
   padding: 2px 20px;
-  background-color: lightgray;
-  border-color: lightgray;
+  background-color: #eee;
+  border-color: #e5e5e5;
   border-radius: 2px;
 }
 
 input[type=submit]:hover {
-  background-color: darkgray;
+  background-color: #e5e5e5;
 }
 
 /**
@@ -232,7 +232,7 @@ all select elements and to match Freehub visual style
   display: table;
 }
 
-#errorExplanation { 
+#errorExplanation {
   max-width: 380px;
   border: 2px solid #c00;
   margin-bottom: 20px;

--- a/public/stylesheets/people.css
+++ b/public/stylesheets/people.css
@@ -45,7 +45,7 @@
 
 #note_text {
   height: 60px;
-  width: 380px;
+  width: 100%;
 }
 
 #visits li, #services li, #notes li {

--- a/public/stylesheets/people.css
+++ b/public/stylesheets/people.css
@@ -1,8 +1,13 @@
 #summary {
-  float:right;
   text-align: right;
   font-size: 13px;
   padding: 10px;
+}
+
+@media (max-width: 800px) {
+  #summary {
+    text-align: inherit;
+  }
 }
 
 #summary .person_type {
@@ -32,8 +37,7 @@
 }
 
 #sign_in {
-  width: 400px;
-  float: left;
+  width: 360px;
   padding: 10px;
 }
 

--- a/public/stylesheets/tags.css
+++ b/public/stylesheets/tags.css
@@ -2,6 +2,12 @@
   float: right;
 }
 
+@media (max-width: 800px) {
+  .tags_control {
+    float: inherit;
+  }
+}
+
 .tags_control ul.tags li {
   float: left;
   font-size: 12px;

--- a/test/functional/people_controller_test.rb
+++ b/test/functional/people_controller_test.rb
@@ -45,7 +45,7 @@ class PeopleControllerTest < ActionController::TestCase
           post :create, :organization_key => 'sfbk', :person => { :first_name => "Newbie" }, :visiting => 'true'
     end
     assert_equal 1, assigns(:person).visits.size
-    assert_equal Date.today, assigns(:person).visits.first.arrived_at.to_date
+    assert_equal Time.zone.today, assigns(:person).visits.first.arrived_at.to_date
 
     assert_redirected_to today_visits_path
   end

--- a/test/functional/reports_controller_test.rb
+++ b/test/functional/reports_controller_test.rb
@@ -128,10 +128,21 @@ class ReportsControllerTest < ActionController::TestCase
 
   def test_summary_report
     get :summary, :organization_key => 'sfbk',
-            :criteria => {  :from => '2006-01-01', :to => '2008-01-01' }
+            :criteria => {  :from => '2006-01-01', :to => '2008-01-01' },
+            :chartWidth => "300"
     assert_response :success
     assert assigns(:report)
     assert assigns(:gchart)
+    assert_match "300x120", assigns(:gchart)
   end
+
+
+    def test_summary_report_defaults_chart_width
+      get :summary, :organization_key => 'sfbk',
+              :criteria => {  :from => '2006-01-01', :to => '2008-01-01' },
+              :chartWidth => "foo"
+      assert assigns(:gchart)
+      assert_match "840x120", assigns(:gchart)
+    end
 
 end

--- a/test/unit/visit_test.rb
+++ b/test/unit/visit_test.rb
@@ -42,7 +42,7 @@ class VisitTest < ActiveSupport::TestCase
   end
 
   def test_create_defaults
-    assert_equal Date.today, Visit.create!(:person => people(:mary)).arrived_at.to_date
+    assert_equal Time.zone.today, Visit.create!(:person => people(:mary)).arrived_at.to_date
     assert_equal Time.zone.local(2007,1,1), Visit.create!(:person => people(:mary), :arrived_at => Time.zone.local(2007,1,1)).arrived_at.to_time
     assert_not_nil Visit.new.note
   end
@@ -69,5 +69,3 @@ class VisitTest < ActiveSupport::TestCase
   end
 
 end
-
-


### PR DESCRIPTION
Freehub was originally created before smartphone web browsers and has not been updated to be mobile-friendly. Until now.

This PR adds styling to make the Freehub two column layout collapse to one column on narrow screens. It uses flexbox to accomplish this. 

This PR also adds explicit styling to form elements so they look and behave consistently across desktop and mobile browsers. 

These changes have been testing in:
* Chrome on OS X
* Chrome emulator for various iOS and Android browsers
* Chrome on iPhone 8
* Safari on iPhone 8

Many thanks to @jgravois for kicking off this effort and for helping to bring it across the finish line.