### PR TITLE
SSL-friendly jQuery CDN URL

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -9,7 +9,7 @@
     -else
       -@title = "#{params[:controller].singularize.titleize} #{params[:action].titleize}"
     %title #{@title} on Freehub
-    = javascript_include_tag 'http://ajax.googleapis.com/ajax/libs/jquery/1.4.2/jquery.min.js'
+    = javascript_include_tag '//ajax.googleapis.com/ajax/libs/jquery/1.4.2/jquery.min.js'
     = javascript_include_tag :all
     = stylesheet_link_tag 'reset-min'
     = calendar_date_select_includes 'silver'


### PR DESCRIPTION
Omit protocol loading jquery from CDN so that it will load over HTTPS when page is viewed via HTTPS.