### PR TITLE
small responsive tweaks to improve display on iPhone 5

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -65,9 +65,9 @@
         %div.footer-item
           = link_to 'Freehub', root_path, :id => 'logo'
         %ul.footer-item
-          %li Get #{link_to "help or send feedback", "https://github.com/asalant/freehub/wiki/Freehub-Support"}
-          %li Check the #{link_to 'project documentation', 'https://github.com/asalant/freehub/wiki'}
-        %ul.footer-item
+          %li #{link_to "Get help or send feedback", "https://github.com/asalant/freehub/wiki/Freehub-Support"}
+          %li Check out the #{link_to 'project documentation', 'https://github.com/asalant/freehub/wiki'}
+          %li &nbsp;
           %li Thanks to #{link_to 'EngineYard', 'http://www.engineyard.com'} for hosting
         %div.footer-item
           =image_tag("ey-logo.gif")

--- a/public/stylesheets/application.css
+++ b/public/stylesheets/application.css
@@ -150,7 +150,7 @@ ul.tabs {
 ul.tabs li {
   float:left;
   font-size: 14px;
-  padding: 6px 18px 10px 18px;
+  padding: 6px 14px 10px 14px;
   color: white;
 }
 
@@ -300,7 +300,7 @@ input[type=submit]:hover {
 }
 
 #application_body h1 {
-  font-size: 24px;
+  font-size: 20px;
   padding: 0 0 12px 0;
   line-height: 1em;
 }


### PR DESCRIPTION
I decided that targeting Chrome's built in iPhone 5 mobile simulator would be the best way to ensure that the mobile layout will look good on older/cheaper mobile devices that pack in fewer pixels.

surprising few changes were needed to avoid unexpected overflow on this 320x568px screen.

<img width="448" alt="Screen Shot 2020-01-12 at 8 37 02 PM" src="https://user-images.githubusercontent.com/3011734/72233292-51eda600-357b-11ea-9e4f-bf6da34df8fa.png">

while I was in there, I fixed one more typo in the footer and collapsed the content from two separate `<ul>`s into one to fix the alignment.

