### PR TITLE
right justify EngineYard logo in footer

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -69,7 +69,7 @@
           %li Check the #{link_to 'project documentation', 'https://github.com/asalant/freehub/wiki'}
         %ul.footer-item
           %li Thanks to #{link_to 'EngineYard', 'http://www.engineyard.com'} for hosting
-        %div.footer-item
+        %div.footer-item.credit
           =image_tag("ey-logo.gif")
     :javascript
       var _gaq = _gaq || [];

--- a/public/stylesheets/application.css
+++ b/public/stylesheets/application.css
@@ -143,6 +143,14 @@ ul.tabs {
   }
 }
 
+@media (min-width: 800px) {
+  .credit {
+    margin-left: auto;
+    position: relative;
+    left: -100px;
+  }
+}
+
 ul.tabs li {
   float:left;
   font-size: 14px;

--- a/public/stylesheets/application.css
+++ b/public/stylesheets/application.css
@@ -31,13 +31,6 @@
   width: 100%;
 }
 
-@media (max-width: 800px) {
-  .flex-column {
-    width: 100%;
-    min-width: inherit;
-  }
-}
-
 #footer {
   height: 100px;
 }
@@ -52,12 +45,6 @@
   color: white;
   font-size: 11px;
   background: black;
-}
-
-@media (max-width: 800px) {
-  #footer .body {
-    flex-flow: column;
-  }
 }
 
 .footer-item {
@@ -145,6 +132,15 @@ ul.tabs {
   ul.tabs {
     float: inherit;
   }
+
+  #footer .body {
+    flex-flow: column;
+  }
+
+  .flex-column {
+    width: 100%;
+    min-width: inherit;
+  }
 }
 
 ul.tabs li {
@@ -156,7 +152,6 @@ ul.tabs li {
 
 ul.tabs li a {
   color: white;
-
 }
 
 ul.tabs li.selected,


### PR DESCRIPTION
These tweaks float the EngineYard logo in the footer on the righthand side on desktop screens.

<img width="1041" alt="Screen Shot 2020-01-12 at 9 13 42 PM" src="https://user-images.githubusercontent.com/3011734/72234137-6ed8a800-3580-11ea-8eed-0f4a3c39d13b.png">

While I was in there I couldn't resist consolidating the duplicate media queries, but I separated that work in its own commit in case you prefer to just cherry-pick the other one. 😉 