### PR TITLE
ensure that past visits and reports subroutes also display the selected nav

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -31,7 +31,13 @@ module ApplicationHelper
   end
 
   def tab_item(label, path)
-    "<li class='#{request.path == path ? 'selected' : ''}'><a href='#{path}'>#{label}</a></li>"
+    if label === 'Home'
+      "<li class='#{request.path == path ? 'selected' : ''}'><a href='#{path}'>#{label}</a></li>"
+    elsif label === 'Visits'
+      "<li class='#{request.path.include?('/visits/') ? 'selected' : ''}'><a href='#{path}'>#{label}</a></li>"
+    else
+       "<li class='#{request.path.start_with?(path) ? 'selected' : ''}'><a href='#{path}'>#{label}</a></li>"
+    end
   end
 
   def today_visits_path(params={})


### PR DESCRIPTION
just a small tweak to help the routes below display a selected nav option in the header.

* `/[org]/visits/2020/1/17`
* `/[org]/visits/2020/1/16` (etc.)
* `/[org]/reports/people`
* `[/org]/reports/visits` (etc.)

<img width="491" alt="Screen Shot 2020-01-18 at 11 56 13 AM" src="https://user-images.githubusercontent.com/3011734/72669728-49b5c080-39ea-11ea-8a73-23436ebf334f.png">
