### PR TITLE
Resolve "undefined method `new0' for DateTime:Class"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gem "rails", "2.3.17"
 gem "mysql"
-gem "tzinfo", "~> 0.3.31"  # Resolves "undefined method `new0' for DateTime:Class". See https://www.chiliproject.org/issues/903
+gem "tzinfo", "~> 0.3.31"  # See https://github.com/asalant/freehub/pull/56
 gem "authorization", github:  "asalant/rails-authorization-plugin"
 gem 'json', '1.7.7' # (CVE-2013-026) Can remove once rails depends on > 1.7.6
 gem 'haml', "3.0.25"

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source 'https://rubygems.org'
 
 gem "rails", "2.3.17"
 gem "mysql"
+gem "tzinfo", "~> 0.3.31"  # Resolves "undefined method `new0' for DateTime:Class". See https://www.chiliproject.org/issues/903
 gem "authorization", github:  "asalant/rails-authorization-plugin"
 gem 'json', '1.7.7' # (CVE-2013-026) Can remove once rails depends on > 1.7.6
 gem 'haml', "3.0.25"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,6 +48,7 @@ GEM
     test-unit (3.1.9)
       power_assert
     thoughtbot-shoulda (2.11.1)
+    tzinfo (0.3.56)
     unicorn (5.5.1)
       kgio (~> 2.6)
       raindrops (~> 0.7)
@@ -71,6 +72,7 @@ DEPENDENCIES
   rdoc
   test-unit
   thoughtbot-shoulda
+  tzinfo (~> 0.3.31)
   unicorn
   validates_email_format_of
 


### PR DESCRIPTION
I periodically see this error [reported by Airbrake](https://freehub.airbrake.io/projects/12681/groups/2687231924360486575/notices/2687231896753207013). The relevant part of the stack is:

```
[GEM_ROOT]/gems/activesupport-2.3.17/lib/active_support/vendor/tzinfo-0.3.12/tzinfo/ruby_core_support.rb:52 in datetime_new!
[GEM_ROOT]/gems/activesupport-2.3.17/lib/active_support/vendor/tzinfo-0.3.12/tzinfo/timezone_transition_info.rb:74 in at
[GEM_ROOT]/gems/activesupport-2.3.17/lib/active_support/vendor/tzinfo-0.3.12/tzinfo/data_timezone_info.rb:113 in block in period_for_utc
[GEM_ROOT]/gems/activesupport-2.3.17/lib/active_support/vendor/tzinfo-0.3.12/tzinfo/data_timezone_info.rb:112 in downto
[GEM_ROOT]/gems/activesupport-2.3.17/lib/active_support/vendor/tzinfo-0.3.12/tzinfo/data_timezone_info.rb:112 in period_for_utc
[GEM_ROOT]/gems/activesupport-2.3.17/lib/active_support/vendor/tzinfo-0.3.12/tzinfo/data_timezone.rb:36 in period_for_utc
[GEM_ROOT]/gems/activesupport-2.3.17/lib/active_support/vendor/tzinfo-0.3.12/tzinfo/timezone.rb:375 in block in utc_to_local
[GEM_ROOT]/gems/activesupport-2.3.17/lib/active_support/vendor/tzinfo-0.3.12/tzinfo/time_or_datetime.rb:276 in wrap
[GEM_ROOT]/gems/activesupport-2.3.17/lib/active_support/vendor/tzinfo-0.3.12/tzinfo/timezone.rb:374 in utc_to_local
[GEM_ROOT]/gems/activesupport-2.3.17/lib/active_support/vendor/tzinfo-0.3.12/tzinfo/timezone.rb:426 in now
[GEM_ROOT]/gems/activesupport-2.3.17/lib/active_support/values/time_zone.rb:272 in today
/PROJECT_ROOT/app/helpers/application_helper.rb:38 in today_visits_path
---
```

[Comment 5 in this thread](https://www.chiliproject.org/issues/903#note-5) describes a cause for this error that matches Freehub's versioning exactly.

The fix is to update tzinfo which is what I have done in this PR. The only problem is that I have not been able to reproduce locally and the error happens rarely in production so it will be a matter of just waiting to see if it occurs again.

