### PR TITLE
Added Email Search Function to Reports & People Model, Fixed Bug Where Names Were Auto-Spaced When 2nd Capitalized Letter Detected in Name

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -140,10 +140,10 @@ class Person < ActiveRecord::Base
   end
 
   def titleize_name
-    self.first_name = self.first_name.titleize if !self.first_name.blank?
+    self.first_name = self.first_name.custom_titlecase if !self.first_name.blank?
     if !self.last_name.blank?
       parts = self.last_name.split " "
-      parts << parts.pop.titleize
+      parts << parts.pop.custom_titlecase
       self.last_name = parts.join " "
     end
   end

--- a/app/views/reports/people.html.haml
+++ b/app/views/reports/people.html.haml
@@ -1,7 +1,8 @@
-%h1
-  =link_to 'Reports', reports_path
-  = ' : People'
-%div.column
+%div.flex-column
+  %h1
+    =link_to 'Reports', reports_path
+    = ' : People'
+
   -form_tag report_path(:action => 'people'), :method => :get do
     %ul
       =labeled_input 'Matching name', :for => 'report[matching_name]' do
@@ -11,68 +12,71 @@
       =labeled_input 'Matching email', :for => 'report[matching_email]' do
         -capture do
           %div= text_field_tag 'report[matching_email]', @report[:matching_email]
-          %p.instruct Match letters in a person's email.
+          %p.instruct Match letters in a person's email address.
+
       =labeled_input 'Type', :for => 'report[is_staff]' do
         -capture do
-          %span.option
-            = radio_button_tag 'report[is_staff]', "all", @report[:is_staff] == nil
-            %label{:for => 'report[is_staff]'} All
-          %span.option
-            = radio_button_tag 'report[is_staff]', 1, @report[:is_staff] == "1"
-            %label{:for => 'report[is_staff]'} Staff
-          %span.option
-            = radio_button_tag 'report[is_staff]', 0, @report[:is_staff] == "0"
-            %label{:for => 'report[is_staff]'} Patrons
+          %div
+            %span.option
+              = radio_button_tag 'report[is_staff]', "all", @report[:is_staff] == nil
+              %label{:for => 'report[is_staff]'} All
+            %span.option
+              = radio_button_tag 'report[is_staff]', 1, @report[:is_staff] == "1"
+              %label{:for => 'report[is_staff]'} Staff
+            %span.option
+              = radio_button_tag 'report[is_staff]', 0, @report[:is_staff] == "0"
+              %label{:for => 'report[is_staff]'} Patrons
           %p.instruct Select All, Staff, or Patrons
       =labeled_input 'Date Range', :for => 'date_from' do
         -capture do
           %span
-            =calendar_date_select_tag "report[after]", @report[:after], :year_range => 3.years.ago..1.years.from_now
+            =calendar_date_select_tag "report[after]", @report[:after], :year_range => 10.years.ago..1.years.from_now
             %label{:for => 'report[after]'} Created After
           %span
-            =calendar_date_select_tag "report[before]", @report[:before], :year_range => 3.years.ago..1.years.from_now
+            =calendar_date_select_tag "report[before]", @report[:before], :year_range => 10.years.ago..1.years.from_now
             %label{:for => 'report[before]'} Created Before
           %p.instruct Leave one or both blank to search without date constraints.
-      %li 
+      %li
         =submit_tag "Update"
 
-%div.section
-  -if @people.empty?
-    %div.list_status No people for date range.
-  -else
-    %div.list_status #{@people.to_a.size} of #{@people.size} people shown.
-    %table
-      %tr
-      %th Name
-      %th Staff
-      %th Email
-      %th Phone
-      %th City
-      %th State
-      %th Postal code
-      %th Created
-      -for person in @people
-        %tr{:class => cycle('odd','even')}
-          %td{:style => 'width:200px;'}
-            =link_to(person.full_name, person_path(:id => person))
-          %td
-            = person.staff
-          %td{:style => 'width:200px;'}
-            = person.email
-          %td 
-            = person.phone
-          %td 
-            = person.city
-          %td 
-            = person.state
-          %td 
-            = person.postal_code
-          %td 
-            = datetime_short(person.created_at)
-      %tr.list_controls
-        %td{:colspan => 8}
-          -if @people.next_page? || @people.previous_page?
-            %div.paginating_links
-              More: #{paginating_links(@people, :params => { :report => params[:report] } )}
-          %div.export
-            =link_to 'Export all', report_path(:action => 'people', :params => { :report => params[:report], :format => 'csv' })
+%div.flex-fullwidth
+  %div.section
+    -if @people.empty?
+      %div.list_status No people for date range.
+    -else
+      %div.list_status #{@people.to_a.size} of #{@people.size} people shown.
+      %table
+        %tr
+        %th Name
+        %th Staff
+        %th Email
+        %th Phone
+        %th City
+        %th State
+        %th Postal code
+        %th Created
+        -for person in @people
+          %tr{:class => cycle('odd','even')}
+            %td{:style => 'width:200px;'}
+              =link_to(person.full_name, person_path(:id => person))
+            %td
+              = person.staff
+            %td{:style => 'width:200px;'}
+              = person.email
+            %td
+              = person.phone
+            %td
+              = person.city
+            %td
+              = person.state
+            %td
+              = person.postal_code
+            %td
+              = datetime_short(person.created_at)
+        %tr.list_controls
+          %td{:colspan => 8}
+            -if @people.next_page? || @people.previous_page?
+              %div.paginating_links
+                More: #{paginating_links(@people, :params => { :report => params[:report] } )}
+            %div.export
+              =link_to 'Export all', report_path(:action => 'people', :params => { :report => params[:report], :format => 'csv' })

--- a/app/views/reports/people.html.haml
+++ b/app/views/reports/people.html.haml
@@ -1,77 +1,78 @@
-%div.flex-column
-  %h1
-    =link_to 'Reports', reports_path
-    = ' : People'
-
+%h1
+  =link_to 'Reports', reports_path
+  = ' : People'
+%div.column
   -form_tag report_path(:action => 'people'), :method => :get do
     %ul
       =labeled_input 'Matching name', :for => 'report[matching_name]' do
         -capture do
           %div= text_field_tag 'report[matching_name]', @report[:matching_name]
           %p.instruct Match 3 or more letters in a person's first and last name.
+      =labeled_input 'Matching email', :for => 'report[matching_email]' do
+        -capture do
+          %div= text_field_tag 'report[matching_email]', @report[:matching_email]
+          %p.instruct Match letters in a person's email.
       =labeled_input 'Type', :for => 'report[is_staff]' do
         -capture do
-          %div
-            %span.option
-              = radio_button_tag 'report[is_staff]', "all", @report[:is_staff] == nil
-              %label{:for => 'report[is_staff]'} All
-            %span.option
-              = radio_button_tag 'report[is_staff]', 1, @report[:is_staff] == "1"
-              %label{:for => 'report[is_staff]'} Staff
-            %span.option
-              = radio_button_tag 'report[is_staff]', 0, @report[:is_staff] == "0"
-              %label{:for => 'report[is_staff]'} Patrons
+          %span.option
+            = radio_button_tag 'report[is_staff]', "all", @report[:is_staff] == nil
+            %label{:for => 'report[is_staff]'} All
+          %span.option
+            = radio_button_tag 'report[is_staff]', 1, @report[:is_staff] == "1"
+            %label{:for => 'report[is_staff]'} Staff
+          %span.option
+            = radio_button_tag 'report[is_staff]', 0, @report[:is_staff] == "0"
+            %label{:for => 'report[is_staff]'} Patrons
           %p.instruct Select All, Staff, or Patrons
       =labeled_input 'Date Range', :for => 'date_from' do
         -capture do
           %span
-            =calendar_date_select_tag "report[after]", @report[:after], :year_range => 10.years.ago..1.years.from_now
+            =calendar_date_select_tag "report[after]", @report[:after], :year_range => 3.years.ago..1.years.from_now
             %label{:for => 'report[after]'} Created After
           %span
-            =calendar_date_select_tag "report[before]", @report[:before], :year_range => 10.years.ago..1.years.from_now
+            =calendar_date_select_tag "report[before]", @report[:before], :year_range => 3.years.ago..1.years.from_now
             %label{:for => 'report[before]'} Created Before
           %p.instruct Leave one or both blank to search without date constraints.
-      %li
+      %li 
         =submit_tag "Update"
 
-%div.flex-fullwidth
-  %div.section
-    -if @people.empty?
-      %div.list_status No people for date range.
-    -else
-      %div.list_status #{@people.to_a.size} of #{@people.size} people shown.
-      %table
-        %tr
-        %th Name
-        %th Staff
-        %th Email
-        %th Phone
-        %th City
-        %th State
-        %th Postal code
-        %th Created
-        -for person in @people
-          %tr{:class => cycle('odd','even')}
-            %td{:style => 'width:200px;'}
-              =link_to(person.full_name, person_path(:id => person))
-            %td
-              = person.staff
-            %td{:style => 'width:200px;'}
-              = person.email
-            %td
-              = person.phone
-            %td
-              = person.city
-            %td
-              = person.state
-            %td
-              = person.postal_code
-            %td
-              = datetime_short(person.created_at)
-        %tr.list_controls
-          %td{:colspan => 8}
-            -if @people.next_page? || @people.previous_page?
-              %div.paginating_links
-                More: #{paginating_links(@people, :params => { :report => params[:report] } )}
-            %div.export
-              =link_to 'Export all', report_path(:action => 'people', :params => { :report => params[:report], :format => 'csv' })
+%div.section
+  -if @people.empty?
+    %div.list_status No people for date range.
+  -else
+    %div.list_status #{@people.to_a.size} of #{@people.size} people shown.
+    %table
+      %tr
+      %th Name
+      %th Staff
+      %th Email
+      %th Phone
+      %th City
+      %th State
+      %th Postal code
+      %th Created
+      -for person in @people
+        %tr{:class => cycle('odd','even')}
+          %td{:style => 'width:200px;'}
+            =link_to(person.full_name, person_path(:id => person))
+          %td
+            = person.staff
+          %td{:style => 'width:200px;'}
+            = person.email
+          %td 
+            = person.phone
+          %td 
+            = person.city
+          %td 
+            = person.state
+          %td 
+            = person.postal_code
+          %td 
+            = datetime_short(person.created_at)
+      %tr.list_controls
+        %td{:colspan => 8}
+          -if @people.next_page? || @people.previous_page?
+            %div.paginating_links
+              More: #{paginating_links(@people, :params => { :report => params[:report] } )}
+          %div.export
+            =link_to 'Export all', report_path(:action => 'people', :params => { :report => params[:report], :format => 'csv' })

--- a/app/views/reports/people.html.haml
+++ b/app/views/reports/people.html.haml
@@ -13,7 +13,6 @@
         -capture do
           %div= text_field_tag 'report[matching_email]', @report[:matching_email]
           %p.instruct Match letters in a person's email address.
-
       =labeled_input 'Type', :for => 'report[is_staff]' do
         -capture do
           %div

--- a/config/initializers/custom_titlecase.rb
+++ b/config/initializers/custom_titlecase.rb
@@ -1,0 +1,5 @@
+class String
+    def custom_titlecase
+        self.gsub(/\b\w/) { |w| w.upcase }
+    end
+end

--- a/test/unit/person_test.rb
+++ b/test/unit/person_test.rb
@@ -31,6 +31,7 @@ class PersonTest < ActiveSupport::TestCase
     assert_equal 'First Last', Person.create!(:organization => organizations(:sfbk), :first_name => 'first', :last_name => 'last').full_name
     assert_equal 'First de Last', Person.create!(:organization => organizations(:sfbk), :first_name => 'first', :last_name => 'de last').full_name
     assert_equal 'Erik Dölerud', Person.create!(:organization => organizations(:sfbk), :first_name => 'erik', :last_name => 'dölerud').full_name
+    assert_equal 'First McLast', Person.create!(:organization => organizations(:sfbk), :first_name => 'First', :last_name => 'McLast').full_name
   end
 
   def test_validates_yob

--- a/test/unit/person_test.rb
+++ b/test/unit/person_test.rb
@@ -65,6 +65,11 @@ class PersonTest < ActiveSupport::TestCase
     assert_equal 2, Person.for_organization(organizations(:sfbk)).matching_name('ma').size
   end
 
+  def test_matching_email
+    assert_equal 2, Person.matching_email('ma').size
+    assert_equal 1, Person.matching_email('mary@example.com').size
+  end
+
   def test_in_date_range
     from, to = Date.new(2007,1,1), Date.new(2008,1,3)
     assert_equal 8, Person.after(from).size


### PR DESCRIPTION
By the way, I did not test this. I couldn't get it running locally via the current instructions unfortunately.  Kept running into "We're sorry, but something went wrong. We've been notified about this issue and we'll take a look at it shortly." error page. This code is from an old email I pulled up when I had it working locally at some point in the past. Anyways, it worked in the past (I think sometime around 2017?), so I assume it probably still works (hopefully), but proceed with caution if possible.