### PR TITLE
Use MariaDB 10.0 instead of MySQL 5.6 in development

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,7 +11,7 @@ app:
   links:
     - mysql
 mysql:
-  image: mysql:5.6
+  image: mariadb:10.0 # Matches features of mysql:5.6
   environment:
     - MYSQL_ROOT_PASSWORD=password
   ports:


### PR DESCRIPTION
This change resolves an issue where MySQL fails to start in development with M1 Macs. MariaDB 10.0 matches the version MySQL 5.6.