### PR TITLE
Switch to https:// URL format for authorization plugin

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,7 @@
-version: 2 # use CircleCI 2.0
+version: 2.1 # use CircleCI 2.1
+orbs: 
+  docker: circleci/docker@2.1.2
+  jq: circleci/jq@2.2.0
 jobs: # a collection of steps
   build: # runs not using Workflows must have a `build` job as entry point
     parallelism: 3 # run three instances of this job in parallel
@@ -14,6 +17,7 @@ jobs: # a collection of steps
           MYSQL_ROOT_PASSWORD=password
     steps: # a collection of executable commands
       - checkout # special step to check out source code to working directory
+      - docker/install-dockerize # We use dockerize
 
       # Install compatible bundler
       - run:
@@ -38,12 +42,6 @@ jobs: # a collection of steps
             - vendor/bundle
 
       # Our primary container isn't MYSQL so wait for it
-      - run:
-          name: Install dockerize
-          command: wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
-          environment:
-            DOCKERIZE_VERSION: v0.6.1
-
       - run:
           name: Waiting for MySQL to be ready
           command: dockerize -wait tcp://localhost:3306 -timeout 1m

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 gem "rails", "2.3.17"
 gem "mysql"
 gem "tzinfo", "~> 0.3.31"  # See https://github.com/asalant/freehub/pull/56
-gem "authorization", github:  "asalant/rails-authorization-plugin"
+gem 'authorization', git:  "https://github.com/asalant/rails-authorization-plugin"
 gem 'json', '1.7.7' # (CVE-2013-026) Can remove once rails depends on > 1.7.6
 gem 'haml', "3.0.25"
 gem 'googlecharts', "1.6.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GIT
-  remote: git://github.com/asalant/rails-authorization-plugin.git
+  remote: https://github.com/asalant/rails-authorization-plugin
   revision: 505bd47addf2ef5e3b5d98a7ea8d1352c2aa4ee6
   specs:
     authorization (1.0.12)


### PR DESCRIPTION
Replace deprecated repo URL format.