### PR TITLE
Bugfix: expire homepage cache on configured schedule

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,14 +19,15 @@ gem "acts-as-taggable-on", "2.0.6"
 gem 'airbrake', '~> 3.1'
 gem 'validates_email_format_of'
 gem 'rdoc'
+gem 'expiring_memory_store'
 
 group :development, :test do
   gem 'annotate'
   gem 'test-unit'
   gem 'thoughtbot-shoulda'
+  gem 'timecop'
 end
 
 group :production do
   gem 'unicorn'
-  gem 'expiring_memory_store'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -28,4 +28,5 @@ end
 
 group :production do
   gem 'unicorn'
+  gem 'expiring_memory_store'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,6 +58,7 @@ GEM
     test-unit (3.1.9)
       power_assert
     thoughtbot-shoulda (2.11.1)
+    timecop (0.9.10)
     tzinfo (0.3.61)
     unicorn (5.5.1)
       kgio (~> 2.6)
@@ -87,6 +88,7 @@ DEPENDENCIES
   rdoc
   test-unit
   thoughtbot-shoulda
+  timecop
   tzinfo (~> 0.3.61)
   unicorn
   validates_email_format_of

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,6 +44,7 @@ GEM
       rake (>= 0.8.7)
     builder (3.3.0)
     calendar_date_select (1.16.1)
+    expiring_memory_store (0.1.2)
     haml (3.0.25)
     json (1.7.7)
     kgio (2.11.2)
@@ -77,6 +78,7 @@ DEPENDENCIES
   annotate
   authorization!
   calendar_date_select (= 1.16.1)
+  expiring_memory_store
   haml (= 3.0.25)
   json (= 1.7.7)
   mysql

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -17,6 +17,8 @@ config.action_view.cache_template_loading            = true
 
 # Use a different cache store in production
 # config.cache_store = :mem_cache_store
+require 'active_support/cache/expiring_memory_store'
+config.cache_store = :expiring_memory_store
 
 # Enable serving of images, stylesheets, and javascripts from an asset server
 # config.action_controller.asset_host = "http://assets.example.com"

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -9,9 +9,11 @@ config.cache_classes = true
 # Log error messages when you accidentally call methods on nil.
 config.whiny_nils = true
 
-# Show full error reports and disable caching
+# Show full error reports and enable caching with ExpiringMemoryStore
 config.action_controller.consider_all_requests_local = true
-config.action_controller.perform_caching             = false
+config.action_controller.perform_caching             = true
+require 'active_support/cache/expiring_memory_store'
+config.cache_store = :expiring_memory_store
 
 # Disable request forgery protection in test environment
 config.action_controller.allow_forgery_protection    = false

--- a/test/functional/organizations_controller_test.rb
+++ b/test/functional/organizations_controller_test.rb
@@ -1,7 +1,54 @@
 require 'test_helper'
+require 'timecop'
 
 class OrganizationsControllerTest < ActionController::TestCase
-      
+
+  def setup
+    ActionController::Base.cache_store.clear
+  end
+
+  def test_index_is_cached_for_anonymous_users
+    get :index
+    first_body = @response.body
+
+    User.current_user = nil
+    Visit.create!(:person => people(:daryl), :arrived_at => Time.zone.now)
+
+    get :index
+    second_body = @response.body
+
+    assert_equal first_body, second_body, "Expected cached response for anonymous user"
+  end
+
+  def test_index_cache_is_not_used_for_logged_in_users
+    login_as 'sfbk'
+
+    get :index
+    first_body = @response.body
+
+    Visit.create!(:person => people(:daryl), :arrived_at => Time.zone.now)
+
+    get :index
+    second_body = @response.body
+
+    assert_not_equal first_body, second_body, "Expected fresh response for logged-in user"
+  end
+
+  def test_index_cache_expires
+    get :index
+    first_body = @response.body
+
+    User.current_user = nil
+    Visit.create!(:person => people(:daryl), :arrived_at => Time.zone.now)
+
+    Timecop.travel(25.hours.from_now) do
+      get :index
+      second_body = @response.body
+
+      assert_not_equal first_body, second_body, "Expected cache to expire after 25 hours"
+    end
+  end
+
   def test_should_get_index
     get :index
     assert_response :success


### PR DESCRIPTION
The default MemoryStore in Rails 2.3 ignores expires_in, causing the homepage action cache to persist indefinitely since instance start up. Switch to ExpiringMemoryStore so the existing 24-hour TTL is honored.